### PR TITLE
Fixes issues with capital letters and spaces

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -39,15 +39,15 @@ func (cst *Constraint) Definition() string {
 	//Therefore we need to omit these clauses as well if the UpdateRule or DeleteRule == "RESTRICT"
 	deleteRule := ""
 	if cst.DeleteRule != "RESTRICT" {
-		deleteRule = fmt.Sprintf("ON DELETE %s", cst.DeleteRule)
+		deleteRule = fmt.Sprintf(" ON DELETE %s", cst.DeleteRule)
 	}
 
 	updateRule := ""
 	if cst.UpdateRule != "RESTRICT" {
-		updateRule = fmt.Sprintf("ON UPDATE %s", cst.UpdateRule)
+		updateRule = fmt.Sprintf(" ON UPDATE %s", cst.UpdateRule)
 	}
 
-	def := fmt.Sprintf("CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) %s %s",
+	def := fmt.Sprintf("CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)%s%s",
 		EscapeIdentifier(cst.Name),
 		EscapeIdentifier(cst.Column.Name),
 		referencedIdentifierName,

--- a/schema.go
+++ b/schema.go
@@ -308,9 +308,9 @@ func (s *Schema) Tables() ([]*Table, error) {
 		// contraint definition.
 		// If however it just references a table inside the current database/schema (s.Name), just provide "" to signal that we do not need it
 		referencedSchemaName := ""
-		if rawConstraint.ReferencedSchemaName != s.Name {
-			referencedSchemaName = rawConstraint.ReferencedSchemaName
-		}
+		if strings.ToLower(rawConstraint.ReferencedSchemaName) != strings.ToLower(s.Name) {
+                referencedSchemaName = rawConstraint.ReferencedSchemaName
+        }
 
 		fullColNameStr := fmt.Sprintf("%s.%s.%s", s.Name, rawConstraint.TableName, rawConstraint.ColumnName)
 		column := columnsByTableAndName[fullColNameStr]
@@ -338,9 +338,9 @@ func (s *Schema) Tables() ([]*Table, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error executing SHOW CREATE TABLE: %s", err)
 		}
-		if t.createStatement != t.GeneratedCreateStatement() {
-			t.UnsupportedDDL = true
-		}
+		if strings.ToLower(t.createStatement) != strings.ToLower(t.GeneratedCreateStatement()) {
+                t.UnsupportedDDL = true
+        }
 	}
 
 	return s.tables, nil

--- a/schema.go
+++ b/schema.go
@@ -295,9 +295,9 @@ func (s *Schema) Tables() ([]*Table, error) {
 		// contraint definition.
 		// If however it just references a table inside the current database/schema (s.Name), just provide "" to signal that we do not need it
 		referencedSchemaName := ""
-		if strings.ToLower(rawConstraint.ReferencedSchemaName) != strings.ToLower(s.Name) {
-                referencedSchemaName = rawConstraint.ReferencedSchemaName
-        }
+		if rawConstraint.ReferencedSchemaName != s.Name {
+			referencedSchemaName = rawConstraint.ReferencedSchemaName
+		}
 
 		fullColNameStr := fmt.Sprintf("%s.%s.%s", s.Name, rawConstraint.TableName, rawConstraint.ColumnName)
 		column := columnsByTableAndName[fullColNameStr]
@@ -325,9 +325,9 @@ func (s *Schema) Tables() ([]*Table, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error executing SHOW CREATE TABLE: %s", err)
 		}
-		if strings.ToLower(t.createStatement) != strings.ToLower(t.GeneratedCreateStatement()) {
-                t.UnsupportedDDL = true
-        }
+		if t.createStatement != t.GeneratedCreateStatement() {
+			t.UnsupportedDDL = true
+		}
 	}
 
 	return s.tables, nil


### PR DESCRIPTION
Hi Evan

**Fix 1:**
I realised that my Definition() was slightly off and left excess spaces at times. This caused the incorrect DDL unsupported error.

**Fix 2**
I also came across a very interesting problem to do with the way MySQL handles capital letters. If you use the` ALTER TABLE` statement manually to add a foreign index, you can place in that statement any possible capitalisation of the target schema name. 
This poses a problem if the schema name that MySQL stores differs in its capitalisation.

The result is the unsupported DDL error.

I know that MySQL doesn't care about capital letters - they don't make something unique. However in naming conventions they are very important. I think what we need to do is maintain the user's desired capitalisation BUT make all comparison statements case-insensitive. I have suggested two ways to implement this in the PR but I suspect there are many more places; for instance in every Constraint.Equals(), Index.Equals(), Column.Equals() etc.

I would be interested to hear your opinion of this.

Kind Regards

Chris