### PR TITLE
Remove `AUTO_INCREMENT=%d` from UnsupportDDL check.

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -268,7 +268,9 @@ func (s *Schema) Tables() ([]*Table, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error executing SHOW CREATE TABLE: %s", err)
 		}
-		if t.createStatement != t.GeneratedCreateStatement() {
+		beforeTable, _ := ParseCreateAutoInc(t.createStatement)
+		afterTable, _ := ParseCreateAutoInc(t.GeneratedCreateStatement())
+		if beforeTable != afterTable {
 			t.UnsupportedDDL = true
 		}
 	}


### PR DESCRIPTION
Currently when I run a `skeema pull`, tables where the AUTO_INCREMENT value has increased is showing up as unsupported. This change will remove the AUTO_INCREMENT from the tables so UnsupportedDDL won't be set if the numbers are different.

cc: https://github.com/skeema/skeema/pull/15, @evanelias