### PR TITLE
-- Fix to support bit fields when generating DDL statements.

### DIFF
--- a/column.go
+++ b/column.go
@@ -28,6 +28,8 @@ func ColumnDefaultValue(value string) ColumnDefault {
 // represents a SQL expression, which won't be wrapped in quotes. Traditionally
 // in MySQL this must be either "CURRENT_TIMESTAMP" or, if using fractional
 // second precision, "CURRENT_TIMESTAMP(N)" where N is a digit.
+// This form may also be used to bit literals, which use b'n' syntax and don't require
+// the digit represented by n to be quoted.
 func ColumnDefaultExpression(expression string) ColumnDefault {
 	return ColumnDefault{Value: expression}
 }

--- a/schema.go
+++ b/schema.go
@@ -155,6 +155,8 @@ func (s *Schema) Tables() ([]*Table, error) {
 			col.Default = ColumnDefaultNull
 		} else if strings.HasPrefix(rawColumn.Default.String, "CURRENT_TIMESTAMP") && (strings.HasPrefix(rawColumn.Type, "timestamp") || strings.HasPrefix(rawColumn.Type, "datetime")) {
 			col.Default = ColumnDefaultExpression(rawColumn.Default.String)
+		} else if strings.HasPrefix(rawColumn.Type,"bit") && strings.HasPrefix(rawColumn.Default.String,"b'") {
+			col.Default = ColumnDefaultExpression(rawColumn.Default.String)
 		} else {
 			col.Default = ColumnDefaultValue(rawColumn.Default.String)
 		}

--- a/tengo_test.go
+++ b/tengo_test.go
@@ -55,6 +55,11 @@ func aTable(nextAutoInc uint64) Table {
 			TypeInDB: "tinyint(1)",
 			Default:  ColumnDefaultValue("1"),
 		},
+		&Column{
+			Name:     "alive_bit",
+			TypeInDB: "bit(1)",
+			Default:  ColumnDefaultExpression("b'1'"),
+		},
 	}
 	secondaryIndexes := []*Index{
 		&Index{
@@ -81,11 +86,11 @@ func aTable(nextAutoInc uint64) Table {
   `+"`"+`last_update`+"`"+` timestamp(2) NOT NULL DEFAULT CURRENT_TIMESTAMP(2) ON UPDATE CURRENT_TIMESTAMP(2),
   `+"`"+`ssn`+"`"+` char(10) NOT NULL,
   `+"`"+`alive`+"`"+` tinyint(1) NOT NULL DEFAULT '1',
+  `+"`"+`alive_bit`+"`"+` bit(1) NOT NULL DEFAULT b'1',
   PRIMARY KEY (`+"`"+`actor_id`+"`"+`),
   UNIQUE KEY `+"`"+`idx_ssn`+"`"+` (`+"`"+`ssn`+"`"+`),
   KEY `+"`"+`idx_actor_name`+"`"+` (`+"`"+`last_name`+"`"+`(10),`+"`"+`first_name`+"`"+`(1))
 ) ENGINE=InnoDB%s DEFAULT CHARSET=utf8`, autoIncClause)
-
 	return Table{
 		Name:              "actor",
 		Engine:            "InnoDB",


### PR DESCRIPTION
The entirety of the fix is to add a condition at line 158 of schema.go
to specify non-quoted handling for default bit values.

There is also an update to aTable() in test fixture generator to
add a bit column to the schema.

There is one test that is failing:
--- FAIL: TestTableAlterModifyColumn (0.00s)
	table_test.go:314: Incorrect number of table alters: expected 3, found 4

I think that the test is making assumptions about the number of columns in the table
fixture and I wasn't certain of exactly the right approach here. If you have an idea
I can take a stab at it, or feel free to modify the test :)