### PR TITLE
Integration testing suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,18 @@ notifications:
   email: false
 
 env:
-  TENGO_TEST_IMAGES="mysql:5.6,mysql:5.7"
+  global:
+    - TENGO_TEST_IMAGES="mysql:5.6,mysql:5.7"
+
+before_install:
+  - go get golang.org/x/lint/golint
+  - go get github.com/mattn/goveralls
+
+script:
+  - go test -v -coverprofile=coverage.out -covermode=count
+  - go vet ./...
+  - test -z "$(gofmt -s -d . 2>&1)"
+  - golint -set_exit_status ./...
+
+after_script:
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ services:
 notifications:
   email: false
 
+env:
+  TENGO_TEST_IMAGES="mysql:5.6,mysql:5.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+language: go
+go:
+  - "1.10.x"
+services:
+  - docker
+
+notifications:
+  email: false
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Go La Tengo
 
+[![build status](https://img.shields.io/travis/skeema/tengo/master.svg)](http://travis-ci.org/skeema/tengo)
+[![code coverage](https://img.shields.io/coveralls/skeema/tengo.svg)](https://coveralls.io/r/skeema/tengo)
+[![godoc](https://img.shields.io/badge/godoc-master-blue.svg)](https://godoc.org/github.com/skeema/tengo)
+
 Hoboken's finest indie Golang database automation library
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Go La Tengo currently only aims to support MySQL, MariaDB, and Percona Server. S
 * http://github.com/go-sql-driver/mysql (Mozilla Public License 2.0)
 * http://github.com/jmoiron/sqlx (MIT License)
 * http://github.com/VividCortex/mysqlerr (MIT License)
+* http://github.com/fsouza/go-dockerclient (BSD License)
 
 ## Credits
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,78 @@
+package tengo
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func (s TengoIntegrationSuite) TestIsDatabaseError(t *testing.T) {
+	err1 := errors.New("non-db error")
+	if IsDatabaseError(err1) {
+		t.Errorf("IsDatabaseError unexpectedly returned true for non-database error type=%T", err1)
+	}
+	_, err2 := s.d.Connect("doesnt_exist", "")
+	if !IsDatabaseError(err2) {
+		t.Errorf("IsDatabaseError unexpectedly returned false for error of type=%T", err2)
+	}
+}
+
+func (s TengoIntegrationSuite) TestIsSyntaxError(t *testing.T) {
+	err := errors.New("non-db error")
+	if IsSyntaxError(err) {
+		t.Errorf("IsSyntaxError unexpectedly returned true for non-database error type=%T", err)
+	}
+
+	db, err := s.d.Connect("testing", "")
+	if err != nil {
+		t.Fatalf("Unable to get connection")
+	}
+	_, err = db.Exec("ALTER TAABBEL actor ENGINE=InnoDB")
+	if err == nil {
+		t.Error("Bad syntax still returned nil error unexpectedly")
+
+	} else if !IsSyntaxError(err) {
+		t.Errorf("Error of type %T %+v unexpectedly not considered syntax error", err, err)
+	}
+	_, err = db.Exec("ALTER TABLE doesnt_exist ENGINE=InnoDB")
+	if err == nil {
+		t.Error("Bad alter still returned nil error unexpectedly")
+	} else if IsSyntaxError(err) {
+		t.Errorf("Error of type %T %+v unexpectedly considered syntax error", err, err)
+	}
+}
+
+func (s TengoIntegrationSuite) TestIsAccessError(t *testing.T) {
+	err := errors.New("non-db error")
+	if IsAccessError(err) {
+		t.Errorf("IsAccessError unexpectedly returned true for non-database error type=%T", err)
+	}
+
+	inst := s.d.Instance
+	inst.Lock()
+	for key, connPool := range inst.connectionPool {
+		connPool.Close()
+		delete(inst.connectionPool, key)
+	}
+	inst.Unlock()
+
+	// Hack username in DSN to no longer be correct
+	inst.BaseDSN = fmt.Sprintf("badname%s", inst.BaseDSN)
+	_, err = inst.Connect("", "")
+	if err == nil {
+		t.Error("Connect unexpectedly returned nil error")
+	} else if !IsAccessError(err) {
+		t.Errorf("Error of type %T %+v unexpectedly not considered access error", err, err)
+	}
+	inst.BaseDSN = inst.BaseDSN[7:]
+	db, err := inst.Connect("testing", "")
+	if err != nil {
+		t.Errorf("Connect unexpectedly returned error: %s", err)
+	}
+	_, err = db.Exec("ALTER TABLE doesnt_exist ENGINE=InnoDB")
+	if err == nil {
+		t.Error("Bad alter still returned nil error unexpectedly")
+	} else if IsAccessError(err) {
+		t.Errorf("Error of type %T %+v unexpectedly considered access error", err, err)
+	}
+}

--- a/instance.go
+++ b/instance.go
@@ -371,7 +371,10 @@ func (instance *Instance) DropSchema(schema *Schema, onlyIfEmpty bool) error {
 }
 
 // AlterSchema changes the character set and/or collation of the supplied schema
-// on instance.
+// on instance. Supply an empty string for newCharSet to only change the
+// collation, or supply an empty string for newCollation to use the default
+// collation of newCharSet. (Supplying an empty string for both is also allowed,
+// but is a no-op.)
 func (instance *Instance) AlterSchema(schema *Schema, newCharSet, newCollation string) error {
 	db, err := instance.Connect(schema.Name, "")
 	if err != nil {
@@ -452,6 +455,17 @@ func (instance *Instance) CloneSchema(src, dest *Schema) error {
 	}
 	dest.PurgeTableCache()
 	return nil
+}
+
+// DefaultCharSetAndCollation returns the instance's default character set and
+// collation
+func (instance *Instance) DefaultCharSetAndCollation() (serverCharSet, serverCollation string, err error) {
+	db, err := instance.Connect("information_schema", "")
+	if err != nil {
+		return
+	}
+	err = db.QueryRow("SELECT @@global.character_set_server, @@global.collation_server").Scan(&serverCharSet, &serverCollation)
+	return
 }
 
 // baseDSN returns a DSN with the database (schema) name and params stripped.

--- a/instance_test.go
+++ b/instance_test.go
@@ -154,3 +154,296 @@ func TestInstanceBuildParamString(t *testing.T) {
 	assertParamString("param1=value1&readTimeout=5s&interpolateParams=0", "param2=value2", "param1=value1&readTimeout=5s&interpolateParams=0&param2=value2")
 	assertParamString("param1=value1&readTimeout=5s&interpolateParams=0", "param1=value3", "param1=value3&readTimeout=5s&interpolateParams=0")
 }
+
+func (s TengoIntegrationSuite) TestInstanceConnect(t *testing.T) {
+	// Connecting to invalid schema should return an error
+	db, err := s.d.Connect("does-not-exist", "")
+	if err == nil {
+		t.Error("err is unexpectedly nil")
+	} else if db != nil {
+		t.Error("db is unexpectedly non-nil")
+	}
+
+	// Connecting without specifying a default schema should be successful
+	db, err = s.d.Connect("", "")
+	if err != nil {
+		t.Errorf("Unexpected connection error: %s", err)
+	} else if db == nil {
+		t.Error("db is unexpectedly nil")
+	}
+
+	// Connecting again with same schema and params should return the existing connection pool
+	db2, err := s.d.Connect("", "")
+	if err != nil {
+		t.Errorf("Unexpected connection error: %s", err)
+	} else if db2 != db {
+		t.Errorf("Expected same DB pool to be returned from identical Connect call; instead db=%v and db2=%v", db, db2)
+	}
+
+	// Connecting again with different schema should return a different connection pool
+	db3, err := s.d.Connect("information_schema", "")
+	if err != nil {
+		t.Errorf("Unexpected connection error: %s", err)
+	} else if db3 == db {
+		t.Error("Expected different DB pool to be returned from Connect with different default db; instead was same")
+	}
+
+	// Connecting again with different params should return a different connection pool
+	db4, err := s.d.Connect("information_schema", "foreign_key_checks=0")
+	if err != nil {
+		t.Errorf("Unexpected connection error: %s", err)
+	} else if db4 == db || db4 == db3 {
+		t.Error("Expected different DB pool to be returned from Connect with different params; instead was same")
+	}
+}
+
+func (s TengoIntegrationSuite) TestInstanceSchemas(t *testing.T) {
+	// Currently at least 4 schemas in testdata/integration.sql
+	schemas, err := s.d.Schemas()
+	if err != nil || len(schemas) < 4 {
+		t.Errorf("Expected at least 4 schemas, instead found %d, err=%s", len(schemas), err)
+	}
+
+	// Ensure SchemasByName is returning the same set of schemas
+	byName, err := s.d.SchemasByName()
+	if err != nil {
+		t.Errorf("SchemasByName returned error: %s", err)
+	} else if len(byName) != len(schemas) {
+		t.Errorf("len(byName) != len(schemas): %d vs %d", len(byName), len(schemas))
+	}
+	seen := make(map[string]bool, len(byName))
+	for _, schema := range schemas {
+		if seen[schema.Name] {
+			t.Errorf("Schema %s returned multiple times from call to instance.Schemas", schema.Name)
+		}
+		seen[schema.Name] = true
+		if schema != byName[schema.Name] {
+			t.Errorf("Mismatch for schema %s between Schemas and SchemasByName", schema.Name)
+		}
+		if schema2, err := s.d.Schema(schema.Name); err != nil || schema2 != schema {
+			t.Errorf("Mismatch for schema %s vs instance.Schema(%s); error=%s", schema.Name, schema.Name, err)
+		}
+		if !s.d.HasSchema(schema.Name) {
+			t.Errorf("Expected HasSchema(%s)==true, instead found false", schema.Name)
+		}
+	}
+
+	// Test negative responses
+	if s.d.HasSchema("doesnt_exist") {
+		t.Error("HasSchema(doesnt_exist) unexpectedly returning true")
+	}
+	if schema, err := s.d.Schema("doesnt_exist"); schema != nil || err != nil {
+		t.Errorf("Expected Schema(doesnt_exist) to return nil,nil; instead found %v,%s", schema, err)
+	}
+}
+
+func (s TengoIntegrationSuite) TestInstanceShowCreateTable(t *testing.T) {
+	schema, t1actual := s.GetSchemaAndTable(t, "testing", "actor")
+	t2actual := s.GetTable(t, "testing", "actor_in_film")
+
+	t1create, err1 := s.d.ShowCreateTable(schema, t1actual)
+	t2create, err2 := s.d.ShowCreateTable(schema, t2actual)
+	if err1 != nil || err2 != nil || t1create == "" || t2create == "" {
+		t.Fatalf("Unable to obtain SHOW CREATE TABLE output: err1=%s, err2=%s", err1, err2)
+	}
+
+	t1expected := aTable(1)
+	if t1create != t1expected.createStatement {
+		t.Errorf("Mismatch for SHOW CREATE TABLE\nActual return from %s:\n%s\n----------\nExpected output: %s", s.d.Image, t1create, t1expected.createStatement)
+	}
+	t2expected := anotherTable()
+	if t2create != t2expected.createStatement {
+		t.Errorf("Mismatch for SHOW CREATE TABLE\nActual return from %s:\n%s\n----------\nExpected output: %s", s.d.Image, t2create, t2expected.createStatement)
+	}
+
+	// Test nonexistent table
+	t3 := aTable(123)
+	t3.Name = "doesnt_exist"
+	t3create, err3 := s.d.ShowCreateTable(schema, &t3)
+	if t3create != "" || err3 == nil {
+		t.Errorf("Expected ShowCreateTable on invalid table to return empty string and error, instead err=%s, output=%s", err3, t3create)
+	}
+}
+
+func (s TengoIntegrationSuite) TestInstanceTableSize(t *testing.T) {
+	schema, table := s.GetSchemaAndTable(t, "testing", "has_rows")
+	size, err := s.d.TableSize(schema, table)
+	if err != nil {
+		t.Errorf("Error from TableSize: %s", err)
+	} else if size < 1 {
+		t.Errorf("TableSize returned a non-positive result: %d", size)
+	}
+
+	// Test nonexistent table
+	doesntExist := aTable(123)
+	doesntExist.Name = "doesnt_exist"
+	size, err = s.d.TableSize(schema, &doesntExist)
+	if size > 0 || err == nil {
+		t.Errorf("Expected TableSize to return 0 size and non-nil err for missing table, instead size=%d and err=%s", size, err)
+	}
+}
+
+func (s TengoIntegrationSuite) TestInstanceTableHasRows(t *testing.T) {
+	schema, tableWithRows := s.GetSchemaAndTable(t, "testing", "has_rows")
+	if hasRows, err := s.d.TableHasRows(schema, tableWithRows); err != nil {
+		t.Errorf("Error from TableHasRows: %s", err)
+	} else if !hasRows {
+		t.Error("Expected TableHasRows to return true for has_rows, instead returned false")
+	}
+
+	tableNoRows := s.GetTable(t, "testing", "no_rows")
+	if hasRows, err := s.d.TableHasRows(schema, tableNoRows); err != nil {
+		t.Errorf("Error from TableHasRows: %s", err)
+	} else if hasRows {
+		t.Error("Expected TableHasRows to return false for no_rows, instead returned true")
+	}
+
+	// Test nonexistent table
+	doesntExist := aTable(123)
+	doesntExist.Name = "doesnt_exist"
+	if _, err := s.d.TableHasRows(schema, &doesntExist); err == nil {
+		t.Error("Expected TableHasRows to return error for nonexistent table, but it did not")
+	}
+
+}
+
+func (s TengoIntegrationSuite) TestInstanceCreateSchema(t *testing.T) {
+	_, err := s.d.CreateSchema("foobar", "utf8mb4", "utf8mb4_unicode_ci")
+	if err != nil {
+		t.Fatalf("CreateSchema returned unexpected error: %s", err)
+	}
+	if refetch, err := s.d.Schema("foobar"); err != nil {
+		t.Errorf("Unable to fetch newly created schema: %s", err)
+	} else if refetch.CharSet != "utf8mb4" || refetch.Collation != "utf8mb4_unicode_ci" {
+		t.Errorf("Unexpected charset or collation on refetched schema: %+v", refetch)
+	}
+
+	// Ensure creation of duplicate schema fails with error
+	if _, err := s.d.CreateSchema("foobar", "utf8mb4", "utf8mb4_unicode_ci"); err == nil {
+		t.Error("Expected creation of duplicate schema to return an error, but it did not")
+	}
+
+	// Creation of schema without specifying charset and collation should use
+	// instance defaults
+	defCharSet, defCollation, err := s.d.DefaultCharSetAndCollation()
+	if err != nil {
+		t.Fatalf("Unable to obtain instance default charset and collation")
+	}
+	if schema, err := s.d.CreateSchema("barfoo", "", ""); err != nil {
+		t.Errorf("Failed to create schema with default charset and collation: %s", err)
+	} else if schema.CharSet != defCharSet || schema.Collation != defCollation {
+		t.Errorf("Expected charset/collation to be %s/%s, instead found %s/%s", defCharSet, defCollation, schema.CharSet, schema.Collation)
+	}
+}
+
+func (s TengoIntegrationSuite) TestInstanceDropSchema(t *testing.T) {
+	schema1 := s.GetSchema(t, "testing")      // has tables, and one has rows
+	schema2 := s.GetSchema(t, "testcollate")  // does not have tables
+	schema3 := s.GetSchema(t, "testcharcoll") // has tables, but none have rows
+
+	// Dropping a schema with non-empty tables when onlyIfEmpty==true should fail
+	if err := s.d.DropSchema(schema1, true); err == nil {
+		t.Error("Expected dropping a schema with tables to fail when onlyIfEmpty==true, but it did not")
+	}
+
+	// Dropping a schema without tables when onlyIfEmpty==true should succeed
+	if err := s.d.DropSchema(schema2, true); err != nil {
+		t.Errorf("Expected dropping a schema without tables to succeed when onlyIfEmpty==true, but error=%s", err)
+	}
+
+	// Dropping a schema with only empty tables when onlyIfEmpty==true should succeed
+	if err := s.d.DropSchema(schema3, true); err != nil {
+		t.Errorf("Expected dropping a schema with only empty tables to succeed when onlyIfEmpty==true, but error=%s", err)
+	}
+
+	// Dropping a schema with non-empty tables when onlyIfEmpty==false should succeed
+	if err := s.d.DropSchema(schema1, false); err != nil {
+		t.Errorf("Expected dropping a schema with tables to succeed when onlyIfEmpty==false, but error=%s", err)
+	}
+
+	// Dropping a schema that doesn't exist should fail
+	if err := s.d.DropSchema(schema1, false); err == nil {
+		t.Error("Expected dropping a nonexistent schema to fail, but error was nil")
+	}
+}
+
+func (s TengoIntegrationSuite) TestInstanceAlterSchema(t *testing.T) {
+	assertNoError := func(schema *Schema, newCharSet, newCollation, expectCharSet, expectCollation string) {
+		t.Helper()
+		if err := s.d.AlterSchema(schema, newCharSet, newCollation); err != nil {
+			t.Errorf("Expected alter of %s to (%s,%s) would not error, but returned %s", schema.Name, newCharSet, newCollation, err)
+		} else {
+			if schema.CharSet != expectCharSet {
+				t.Errorf("Expected post-alter charset to be %s, instead found %s", expectCharSet, schema.CharSet)
+			}
+			if schema.Collation != expectCollation {
+				t.Errorf("Expected post-alter collation to be %s, instead found %s", expectCollation, schema.Collation)
+			}
+		}
+	}
+	assertError := func(schema *Schema, newCharSet, newCollation string) {
+		t.Helper()
+		if err := s.d.AlterSchema(schema, newCharSet, newCollation); err == nil {
+			t.Errorf("Expected alter of %s to (%s,%s) would return error, but returned nil instead", schema.Name, newCharSet, newCollation)
+		}
+	}
+
+	schema1 := s.GetSchema(t, "testing")      // instance-default charset and collation
+	schema2 := s.GetSchema(t, "testcharset")  // utf8mb4 charset with its default collation (utf8mb4_general_ci)
+	schema3 := s.GetSchema(t, "testcharcoll") // utf8mb4 with utf8mb4_unicode_ci
+	schema4 := aSchema("nonexistent")
+
+	instCharSet, instCollation, err := s.d.DefaultCharSetAndCollation()
+	if err != nil {
+		t.Fatalf("Unable to fetch instance default charset and collation: %s", err)
+	}
+
+	// Test no-op conditions
+	assertNoError(schema1, "", "", instCharSet, instCollation)
+	assertNoError(schema2, "utf8mb4", "", "utf8mb4", "utf8mb4_general_ci")
+	assertNoError(schema2, "", "utf8mb4_general_ci", "utf8mb4", "utf8mb4_general_ci")
+	assertNoError(schema3, "utf8mb4", "utf8mb4_unicode_ci", "utf8mb4", "utf8mb4_unicode_ci")
+
+	// Test known error conditions
+	assertError(schema1, "badcharset", "badcollation") // charset and collation are invalid
+	assertError(schema2, "utf8", "latin1_swedish_ci")  // charset and collation do not match
+	assertError(&schema4, "utf8mb4", "")               // schema does not actually exist in instance
+
+	// Test successful alters
+	assertNoError(schema2, "", "utf8mb4_unicode_ci", "utf8mb4", "utf8mb4_unicode_ci")
+	assertNoError(schema3, "latin1", "", "latin1", "latin1_swedish_ci")
+	assertNoError(schema1, "utf8mb4", "utf8mb4_general_ci", "utf8mb4", "utf8mb4_general_ci")
+}
+
+func (s TengoIntegrationSuite) TestInstanceCloneSchema(t *testing.T) {
+	src := s.GetSchema(t, "testing")
+	dst, err := s.d.CreateSchema("clone", "", "")
+	if err != nil {
+		t.Fatalf("Failed to create new empty schema: %s", err)
+	}
+	if tables, err := dst.Tables(); err != nil || len(tables) > 0 {
+		t.Fatalf("Failed to verify no tables in new schema: err=%s, len(tables)=%d", err, len(tables))
+	}
+	srcTables, err := src.Tables()
+	if err != nil || len(srcTables) < 1 {
+		t.Fatalf("Failed to obtain non-empty table list for source: err=%s, len(tables)=%d", err, len(srcTables))
+	}
+
+	if err := s.d.CloneSchema(src, dst); err != nil {
+		t.Fatalf("Failed to clone schema: %s", err)
+	}
+	if tables, err := dst.Tables(); err != nil || len(tables) != len(srcTables) {
+		t.Errorf("Failed to verify table count in cloned schema: err=%s, len(srcTables)=%d, len(dstTables)=%d", err, len(srcTables), len(tables))
+	}
+
+	// Cloning again should fail due to table name already existing
+	if err := s.d.CloneSchema(src, dst); err == nil {
+		t.Error("Expected second clone attempt to fail, but error is nil")
+	}
+
+	// Verify that tables were cloned but data was not: dropping dest with
+	// onlyIfEmpty==true should still succeed
+	if err := s.d.DropSchema(dst, true); err != nil {
+		t.Errorf("Error dropping destination schema: %s", err)
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,170 @@
+package tengo
+
+import (
+	"testing"
+)
+
+// TestSchemaTables tests the input and output of Tables(), TablesByName(),
+// HasTable(), and Table(). It does not explicitly validate the introspection
+// logic though; that's handled in TestSchemaIntrospection.
+func (s TengoIntegrationSuite) TestSchemaTables(t *testing.T) {
+	schema := s.GetSchema(t, "testing")
+
+	// Currently at least 7 tables in testing schema in testdata/integration.sql
+	tables, err := schema.Tables()
+	if err != nil || len(tables) < 7 {
+		t.Errorf("Expected at least 7 tables, instead found %d, err=%s", len(tables), err)
+	}
+
+	// Ensure TablesByName is returning the same set of tables
+	byName, err := schema.TablesByName()
+	if err != nil {
+		t.Errorf("TablesByName returned error: %s", err)
+	} else if len(byName) != len(tables) {
+		t.Errorf("len(byName) != len(tables): %d vs %d", len(byName), len(tables))
+	}
+	seen := make(map[string]bool, len(byName))
+	for _, table := range tables {
+		if seen[table.Name] {
+			t.Errorf("Table %s returned multiple times from call to instance.Tables", table.Name)
+		}
+		seen[table.Name] = true
+		if table != byName[table.Name] {
+			t.Errorf("Mismatch for table %s between Tables and TablesByName", table.Name)
+		}
+		if table2, err := schema.Table(table.Name); err != nil || table2 != table {
+			t.Errorf("Mismatch for table %s vs schema.Table(%s); error=%s", table.Name, table.Name, err)
+		}
+		if !schema.HasTable(table.Name) {
+			t.Errorf("Expected HasTable(%s)==true, instead found false", table.Name)
+		}
+	}
+
+	// Test negative responses
+	if schema.HasTable("doesnt_exist") {
+		t.Error("HasTable(doesnt_exist) unexpectedly returning true")
+	}
+	if table, err := schema.Table("doesnt_exist"); table != nil || err != nil {
+		t.Errorf("Expected Table(doesnt_exist) to return nil,nil; instead found %v,%s", table, err)
+	}
+}
+
+func (s TengoIntegrationSuite) TestSchemaIntrospection(t *testing.T) {
+	// Ensure our unit test fixtures and integration test fixtures match
+	schema, aTableFromDB := s.GetSchemaAndTable(t, "testing", "actor")
+	aTableFromUnit := aTable(1)
+	clauses, supported := aTableFromDB.Diff(&aTableFromUnit)
+	if !supported {
+		t.Error("Diff unexpectedly not supported for testing.actor")
+	} else if len(clauses) > 0 {
+		t.Errorf("Diff of testing.actor unexpectedly found %d clauses; expected 0", len(clauses))
+	}
+	aTableFromDB = s.GetTable(t, "testing", "actor_in_film")
+	aTableFromUnit = anotherTable()
+	clauses, supported = aTableFromDB.Diff(&aTableFromUnit)
+	if !supported {
+		t.Error("Diff unexpectedly not supported for testing.actor_in_film")
+	} else if len(clauses) > 0 {
+		t.Errorf("Diff of testing.actor_in_film unexpectedly found %d clauses; expected 0", len(clauses))
+	}
+
+	// ensure tables are all supported (except where known not to be)
+	tables, err := schema.Tables()
+	if err != nil {
+		t.Fatalf("Unexpected error from schema.Tables(): %s", err)
+	}
+	for _, table := range tables {
+		shouldBeUnsupported := (table.Name == unsupportedTable().Name)
+		if table.UnsupportedDDL != shouldBeUnsupported {
+			t.Errorf("Table %s: expected UnsupportedDDL==%v, instead found %v", table.Name, shouldBeUnsupported, !shouldBeUnsupported)
+		}
+	}
+}
+
+func (s TengoIntegrationSuite) TestSchemaOverridesServerCharSet(t *testing.T) {
+	testingSchema := s.GetSchema(t, "testing")
+	testcollateSchema := s.GetSchema(t, "testcollate")
+	testcharsetSchema := s.GetSchema(t, "testcharset")
+	testcharcollSchema := s.GetSchema(t, "testcharcoll")
+
+	// Test logic assumes default of latin1 / latin1_swedish_ci
+	defCharSet, defCollation, err := s.d.DefaultCharSetAndCollation()
+	if err != nil {
+		t.Skip("Unable to obtain instance default charset and collation")
+	}
+	if defCharSet != "latin1" || defCollation != "latin1_swedish_ci" {
+		t.Skipf("Unexpected instance default charset and collation (%s / %s)", defCharSet, defCollation)
+	}
+
+	testTable := []struct {
+		schema                  *Schema
+		expectOverrideCharset   bool
+		expectOverrideCollation bool
+	}{
+		{testingSchema, false, false},
+		{testcollateSchema, false, true},
+		{testcharsetSchema, true, true},
+		{testcharcollSchema, true, true},
+	}
+	for _, testRow := range testTable {
+		overrideCharset, overrideCollation, err := testRow.schema.OverridesServerCharSet()
+		if err != nil {
+			t.Errorf("Unexpected error from OverridesServerCharSet: %s", err)
+		} else {
+			if overrideCharset != testRow.expectOverrideCharset {
+				t.Errorf("Schema %s: Expected overrideCharset=%v, instead found %v", testRow.schema.Name, testRow.expectOverrideCharset, overrideCharset)
+			}
+			if overrideCollation != testRow.expectOverrideCollation {
+				t.Errorf("Schema %s: Expected overrideCollation=%v, instead found %v", testRow.schema.Name, testRow.expectOverrideCollation, overrideCollation)
+			}
+		}
+	}
+
+	// Confirm error returned from calling method on a nil schema
+	var nilSchema *Schema
+	if _, _, err = nilSchema.OverridesServerCharSet(); err == nil {
+		t.Error("Expected OverridesServerCharSet to return error for nil schema, but it did not")
+	}
+}
+
+func (s TengoIntegrationSuite) TestSchemaCachedCopy(t *testing.T) {
+	schema := s.GetSchema(t, "testing")
+
+	clone, err := schema.CachedCopy()
+	if err != nil {
+		t.Errorf("Unexpected error from schema.CachedCopy(): %s", err)
+	}
+
+	// Confirm diff still works
+	sd, err := clone.Diff(schema)
+	if err != nil {
+		t.Errorf("Unexpected error from diff on a cached-copy schema: %s", err)
+	} else if len(sd.TableDiffs) > 0 {
+		t.Error("Non-empty diff unexpectedly returned")
+	}
+
+	// Confirm PurgeTableCache intentionally does not purge anything on a detached
+	// instance
+	if clone.tables == nil {
+		t.Fatal("Incorrect assumption of test (cached copy of schema should already have table cache pre-populated)")
+	}
+	clone.PurgeTableCache()
+	if clone.tables == nil {
+		t.Error("Expected PurgeTableCache to be a no-op on a detached schema, but it was not")
+	}
+
+	// Confirm that methods requiring an instance return an error
+	if _, _, err = clone.OverridesServerCharSet(); err == nil {
+		t.Error("Expected OverridesServerCharSet to fail with detached instance, but it did not")
+	}
+	clone.tables = nil
+	if _, err = clone.Tables(); err == nil {
+		t.Error("Expected Tables() to fail with detached instance with artificially purged table cache, but it did not")
+	}
+
+	// Confirm CachedCopy of nil schema is nil
+	var nilSchema *Schema
+	if clone, err = nilSchema.CachedCopy(); clone != nil || err != nil {
+		t.Error("Cached copy of nil schema did work as expected")
+	}
+}

--- a/tengo_test.go
+++ b/tengo_test.go
@@ -12,7 +12,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration(t *testing.T) {
-	RunSuite(&TengoIntegrationSuite{}, t, "mysql:5.6")
+	images := SplitEnv("TENGO_TEST_IMAGES")
+	if len(images) == 0 {
+		fmt.Println("TENGO_TEST_IMAGES env var is not set, so integration tests will be skipped!")
+		fmt.Println("To run integration tests, you may set TENGO_TEST_IMAGES to a comma-separated")
+		fmt.Println("list of Docker images. Example:\n# TENGO_TEST_IMAGES=\"mysql:5.6,mysql:5.7\" go test")
+	}
+	RunSuite(&TengoIntegrationSuite{}, t, images)
 }
 
 type TengoIntegrationSuite struct {

--- a/testdata/integration.sql
+++ b/testdata/integration.sql
@@ -1,0 +1,97 @@
+CREATE DATABASE testing;
+CREATE DATABASE testcollate DEFAULT COLLATE latin1_bin;
+CREATE DATABASE testcharset DEFAULT CHARACTER SET utf8mb4;
+CREATE DATABASE testcharcoll DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+use testing
+
+# Keep this in sync with tengo_test.go's aTable()
+CREATE TABLE actor (
+	actor_id smallint(5) unsigned NOT NULL AUTO_INCREMENT,
+	first_name varchar(45) NOT NULL,
+	last_name varchar(45) DEFAULT NULL,
+	last_update timestamp(2) NOT NULL DEFAULT CURRENT_TIMESTAMP(2) ON UPDATE CURRENT_TIMESTAMP(2),
+	ssn char(10) NOT NULL,
+	alive tinyint(1) NOT NULL DEFAULT '1',
+	alive_bit bit(1) NOT NULL DEFAULT b'1',
+	PRIMARY KEY (actor_id),
+	UNIQUE KEY idx_ssn (ssn),
+	KEY idx_actor_name (last_name(10),first_name(1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+# Keep this in sync with tengo_test.go's anotherTable()
+CREATE TABLE actor_in_film (
+	actor_id smallint(5) unsigned NOT NULL,
+	film_name varchar(60) NOT NULL,
+	PRIMARY KEY (actor_id,film_name),
+	KEY film_name (film_name)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+# Keep this in sync with tengo_test.go's unsupportedTable()
+CREATE TABLE actor_in_film_with_fk (
+  actor_id smallint(5) unsigned NOT NULL,
+  film_name varchar(60) NOT NULL,
+  PRIMARY KEY (actor_id,film_name),
+  KEY film_name (film_name),
+  CONSTRAINT fk_actor_id FOREIGN KEY (actor_id) REFERENCES actor (actor_id)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE has_rows (
+	id int unsigned NOT NULL AUTO_INCREMENT,
+	name varchar(30),
+	PRIMARY KEY (id)
+);
+INSERT INTO has_rows (name) VALUES
+("Jimbo"),
+("Fred"),
+("Dolph"),
+("Zorgon");
+CREATE TABLE no_rows LIKE has_rows;
+
+CREATE TABLE no_indexes (
+	foo varchar(50),
+	price decimal(10, 2) DEFAULT '99.95'
+);
+
+CREATE TABLE no_pk (
+	name varchar(80) DEFAULT 'a widget has no name',
+	price decimal(10, 2) DEFAULT '99.95',
+	index name_idx (name)
+);
+	
+
+CREATE TABLE eww_myisam (
+	id int unsigned NOT NULL AUTO_INCREMENT,
+	PRIMARY KEY (id)
+) ENGINE=MyISAM;
+
+
+CREATE TABLE grab_bag (
+	id bigint unsigned NOT NULL AUTO_INCREMENT,
+	owner_id int unsigned,
+	name varchar(100) NOT NULL,
+	code char(8) DEFAULT 'XYZ01234',
+	created_at timestamp(2) DEFAULT CURRENT_TIMESTAMP(2),
+	updated_at timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	alive tinyint(1) DEFAULT '1' COMMENT 'column comment',
+	flags bit(8) DEFAULT b'1',
+	PRIMARY KEY (id, code),
+	UNIQUE INDEX name_idx (name),
+	INDEX recency (updated_at, created_at),
+	INDEX owner_idx (owner_id) COMMENT 'index comment'
+) AUTO_INCREMENT=123;
+
+use testcharcoll
+
+CREATE TABLE col_overrides_aplenty (
+	one text CHARACTER SET latin1,
+	two char(20) COLLATE utf8mb4_general_ci,
+	three varchar(30) COLLATE latin1_bin
+);
+
+CREATE TABLE tbl_overrides (
+	four mediumtext,
+	five varchar(45) CHARACTER SET utf8mb4,
+	six char(10) COLLATE latin1_swedish_ci
+) DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,293 @@
+package tengo
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/go-sql-driver/mysql"
+)
+
+// This file contains public functions and structs designed to make integration
+// testing easier. These functions are used in Tengo's own tests, but may also
+// be useful to other packages and applications using Tengo as a library.
+
+// IntegrationTestSuite is the interface for a suite of test methods. In
+// addition to implementing the 3 methods of the interface, an integration test
+// suite struct should have any number of test methods of form
+// TestFoo(t *testing.T), which will be executed automatically by RunSuite.
+type IntegrationTestSuite interface {
+	Setup(backend string) error
+	Teardown(backend string) error
+	BeforeTest(method string, backend string) error
+}
+
+// RunSuite runs all test methods in the supplied suite once per backend. It
+// calls suite.Setup(backend) once per backend, then iterates through all Test
+// methods in suite. For each test method, suite.BeforeTest will be run,
+// followed by the test itself. Finally, suite.Teardown(backend) will be run.
+// Backends are just strings, and may contain docker image names or any other
+// string representation that the test suite understands.
+func RunSuite(suite IntegrationTestSuite, t *testing.T, backends ...string) {
+	var suiteName string
+	suiteType := reflect.TypeOf(suite)
+	suiteVal := reflect.ValueOf(suite)
+	if suiteVal.Kind() == reflect.Ptr {
+		suiteName = suiteVal.Elem().Type().Name()
+	} else {
+		suiteName = suiteType.Name()
+	}
+
+	for _, backend := range backends {
+		if err := suite.Setup(backend); err != nil {
+			log.Printf("Skipping integration test suite %s due to setup failure: %s", suiteName, err)
+			t.Skipf("RunSuite %s: Setup(%s) failed: %s", suiteName, backend, err)
+		}
+
+		// Run test methods
+		for n := 0; n < suiteType.NumMethod(); n++ {
+			method := suiteType.Method(n)
+			if strings.HasPrefix(method.Name, "Test") {
+				if err := suite.BeforeTest(method.Name, backend); err != nil {
+					suite.Teardown(backend)
+					t.Fatalf("RunSuite %s: BeforeTest(%s, %s) failed: %s", suiteName, method.Name, backend, err)
+				}
+				subtestName := fmt.Sprintf("%s.%s:%s", suiteName, method.Name, backend)
+				subtest := func(t *testing.T) {
+					method.Func.Call([]reflect.Value{reflect.ValueOf(suite), reflect.ValueOf(t)})
+				}
+				t.Run(subtestName, subtest)
+			}
+		}
+
+		if err := suite.Teardown(backend); err != nil {
+			t.Fatalf("RunSuite %s: Teardown(%s) failed: %s", suiteName, backend, err)
+		}
+	}
+}
+
+// DockerizedInstance represents a containerized copy of mysql-server, plus a
+// tengo.Instance mapping to it.
+type DockerizedInstance struct {
+	*Instance
+	Container    *docker.Container
+	DockerClient *docker.Client
+	Image        string
+}
+
+// CreateDockerizedInstances creates any number of dockerized mysql-server
+// instances, using the specified image string (such as "mysql:5.6"). If no
+// tag is specified in the string (e.g. just "mysql"), the latest tag will be
+// used automatically.
+func CreateDockerizedInstances(image string, count int) ([]*DockerizedInstance, error) {
+	if count < 0 {
+		return nil, errors.New("CreateDockerizedInstances: count cannot be negative")
+	} else if image == "" {
+		return nil, errors.New("CreateDockerizedInstances: image cannot be empty string")
+	}
+
+	client, err := docker.NewClientFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := strings.SplitN(image, ":", 2)
+	repository := tokens[0]
+	tag := "latest"
+	if len(tokens) > 1 {
+		tag = tokens[1]
+	}
+
+	// Pull image from remote if missing
+	if _, err := client.InspectImage(image); err != nil {
+		opts := docker.PullImageOptions{
+			Repository: repository,
+			Tag:        tag,
+		}
+		if err := client.PullImage(opts, docker.AuthConfiguration{}); err != nil {
+			return nil, err
+		}
+	}
+
+	// Create and start containers
+	result := make([]*DockerizedInstance, count)
+	for n := range result {
+		opts := docker.CreateContainerOptions{
+			Config: &docker.Config{
+				Image: image,
+				Env:   []string{"MYSQL_ROOT_PASSWORD=fakepw"},
+			},
+			HostConfig: &docker.HostConfig{
+				PublishAllPorts: true,
+			},
+		}
+		result[n] = &DockerizedInstance{
+			Image:        image,
+			DockerClient: client,
+		}
+		if result[n].Container, err = client.CreateContainer(opts); err != nil {
+			return result, err
+		}
+		if err := client.StartContainer(result[n].Container.ID, nil); err != nil {
+			return result, err
+		}
+		if result[n].Container, err = client.InspectContainer(result[n].Container.ID); err != nil {
+			return result, err
+		}
+	}
+
+	// Confirm each containerized mysql is reachable, and create Tengo instances
+	for n := range result {
+		result[n].Instance, err = NewInstance("mysql", result[n].DSN())
+		if err != nil {
+			return result, err
+		}
+		var ok bool
+		var connErr error
+		for attempts := 0; !ok && attempts < 80; attempts++ {
+			time.Sleep(250 * time.Millisecond)
+			ok, connErr = result[n].Instance.CanConnect()
+		}
+		if !ok {
+			return result, connErr
+		}
+	}
+
+	return result, nil
+}
+
+// CreateDockerizedInstance creates a single dockerized mysql-server instance
+// using the supplied image name.
+func CreateDockerizedInstance(image string) (*DockerizedInstance, error) {
+	resultSlice, err := CreateDockerizedInstances(image, 1)
+	if len(resultSlice) == 0 {
+		return nil, err
+	}
+	return resultSlice[0], err
+}
+
+// Port returns the actual port number on localhost that maps to the container's
+// internal port 3306.
+func (di *DockerizedInstance) Port() int {
+	portAndProto := docker.Port("3306/tcp")
+	portBindings, ok := di.Container.NetworkSettings.Ports[portAndProto]
+	if !ok || len(portBindings) == 0 {
+		return 0
+	}
+	result, _ := strconv.Atoi(portBindings[0].HostPort)
+	return result
+}
+
+// DSN returns a github.com/go-sql-driver/mysql formatted DSN corresponding
+// to its containerized mysql-server instance.
+func (di *DockerizedInstance) DSN() string {
+	return fmt.Sprintf("root:fakepw@tcp(127.0.0.1:%d)/", di.Port())
+}
+
+func (di *DockerizedInstance) String() string {
+	return fmt.Sprintf("DockerizedInstance:%d", di.Port())
+}
+
+// Destroy stops and deletes the corresponding containerized mysql-server.
+func (di *DockerizedInstance) Destroy() error {
+	if di.Container == nil {
+		return nil
+	}
+	opts := docker.RemoveContainerOptions{
+		ID:            di.Container.ID,
+		Force:         true,
+		RemoveVolumes: true,
+	}
+	if err := di.DockerClient.RemoveContainer(opts); err != nil {
+		return fmt.Errorf("Destroy %s: %s", di, err)
+	}
+	di.Container = nil
+	di.Instance = nil
+	return nil
+}
+
+// NukeData drops all non-system schemas and tables in the containerized
+// mysql-server, making it useful as a per-test cleanup method in
+// implementations of IntegrationTestSuite.BeforeTest.
+func (di *DockerizedInstance) NukeData() error {
+	schemas, err := di.Instance.Schemas()
+	if err != nil {
+		return err
+	}
+	for _, s := range schemas {
+		if err := di.DropSchema(s, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SourceSQL reads the specified file and executes it against the containerized
+// mysql-server. The file should contain one or more valid SQL instructions,
+// typically a mix of DML and/or DDL statements. It is useful as a per-test
+// setup method in implementations of IntegrationTestSuite.BeforeTest.
+func (di *DockerizedInstance) SourceSQL(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("SourceSQL %s: Unable to open setup file %s: %s", di, filePath, err)
+	}
+	opts := docker.CreateExecOptions{
+		AttachStdout: true,
+		AttachStderr: true,
+		AttachStdin:  true,
+		Cmd:          []string{"mysql", "-tvvv", "-pfakepw"},
+		Container:    di.Container.ID,
+	}
+	exec, err := di.DockerClient.CreateExec(opts)
+	if err != nil {
+		return "", err
+	}
+	var stdout, stderr bytes.Buffer
+	startOpts := docker.StartExecOptions{
+		OutputStream: &stdout,
+		ErrorStream:  &stderr,
+		InputStream:  f,
+	}
+	if err = di.DockerClient.StartExec(exec.ID, startOpts); err != nil {
+		return "", err
+	}
+	di.purgeSchemaCache()
+	stdoutStr := stdout.String()
+	stderrStr := strings.Replace(stderr.String(), "Warning: Using a password on the command line interface can be insecure.\n", "", 1)
+	if strings.Contains(stderrStr, "ERROR") {
+		return stdoutStr, fmt.Errorf("SourceSQL %s: Error sourcing file %s: %s", di, filePath, stderrStr)
+	}
+	return stdoutStr, nil
+}
+
+type filteredLogger struct {
+	logger *log.Logger
+}
+
+func (fl filteredLogger) Print(v ...interface{}) {
+	if len(v) > 0 {
+		if err, ok := v[0].(error); ok && err.Error() == "unexpected EOF" {
+			return
+		}
+	}
+	fl.logger.Print(v...)
+}
+
+// UseFilteredDriverLogger overrides the mysql driver's logger to avoid excessive
+// messages. Currently this just suppresses the driver's "unexpected EOF"
+// output, which occurs when an initial connection is refused or a connection
+// drops early.
+func UseFilteredDriverLogger() {
+	fl := filteredLogger{
+		logger: log.New(os.Stderr, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile),
+	}
+	mysql.SetLogger(fl)
+}


### PR DESCRIPTION
This PR adds generic support for performing integration testing against multiple MySQL versions using Docker. It also uses that support to implement an integration testing suite for Tengo, increasing test coverage from 51% to 86%.