### PR TITLE
Remove caching and simplify method args and returns

### DIFF
--- a/ddl.go
+++ b/ddl.go
@@ -173,7 +173,7 @@ type CreateTable struct {
 
 // Statement returns a DDL statement containing CREATE TABLE.
 func (ct CreateTable) Statement(mods StatementModifiers) (string, error) {
-	stmt := ct.Table.CreateStatement()
+	stmt := ct.Table.CreateStatement
 	if ct.Table.HasAutoIncrement() && (mods.NextAutoInc == NextAutoIncIgnore || mods.NextAutoInc == NextAutoIncIfAlready) {
 		stmt, _ = ParseCreateAutoInc(stmt)
 	}

--- a/ddl_test.go
+++ b/ddl_test.go
@@ -35,10 +35,7 @@ func TestParseCreateAutoInc(t *testing.T) {
 
 func TestSchemaDiffEmpty(t *testing.T) {
 	assertEmptyDiff := func(a, b *Schema) {
-		sd, err := NewSchemaDiff(a, b)
-		if err != nil {
-			t.Fatal(err)
-		}
+		sd := NewSchemaDiff(a, b)
 		if len(sd.TableDiffs) != 0 {
 			t.Errorf("Expected no table diffs, instead found %d", len(sd.TableDiffs))
 		}
@@ -61,10 +58,7 @@ func TestSchemaDiffEmpty(t *testing.T) {
 
 func TestSchemaDiffSchemaDDL(t *testing.T) {
 	assertDiffSchemaDDL := func(a, b *Schema, expectedSchemaDDL string) {
-		sd, err := NewSchemaDiff(a, b)
-		if err != nil {
-			t.Fatal(err)
-		}
+		sd := NewSchemaDiff(a, b)
 		if sd.SchemaDDL != expectedSchemaDDL {
 			t.Errorf("For a=%s/%s and b=%s/%s, expected SchemaDDL=\"%s\", instead found \"%s\"", a.CharSet, a.Collation, b.CharSet, b.Collation, expectedSchemaDDL, sd.SchemaDDL)
 		}
@@ -107,10 +101,7 @@ func TestSchemaDiffAddOrDropTable(t *testing.T) {
 	s2 := aSchema("s2", &s2t1, &s2t2)
 
 	// Test table create
-	sd, err := NewSchemaDiff(&s1, &s2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sd := NewSchemaDiff(&s1, &s2)
 	if len(sd.TableDiffs) != 1 {
 		t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 	}
@@ -123,10 +114,7 @@ func TestSchemaDiffAddOrDropTable(t *testing.T) {
 	}
 
 	// Test table drop (opposite diff direction of above)
-	sd, err = NewSchemaDiff(&s2, &s1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sd = NewSchemaDiff(&s2, &s1)
 	if len(sd.TableDiffs) != 1 {
 		t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 	}
@@ -149,10 +137,7 @@ func TestSchemaDiffAddOrDropTable(t *testing.T) {
 	// Test impact of statement modifiers on creation of auto-inc table with non-default starting value
 	s2t2.NextAutoIncrement = 5
 	s2t2.createStatement = s2t2.GeneratedCreateStatement()
-	sd, err = NewSchemaDiff(&s1, &s2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sd = NewSchemaDiff(&s1, &s2)
 	if len(sd.TableDiffs) != 1 {
 		t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 	}
@@ -177,10 +162,7 @@ func TestSchemaDiffAddOrDropTable(t *testing.T) {
 	ust := unsupportedTable()
 	s1 = aSchema("s1")
 	s2 = aSchema("s2", &ust)
-	sd, err = NewSchemaDiff(&s1, &s2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sd = NewSchemaDiff(&s1, &s2)
 	if len(sd.TableDiffs) != 1 {
 		t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 	}
@@ -191,10 +173,7 @@ func TestSchemaDiffAddOrDropTable(t *testing.T) {
 	if td.Table != &ust {
 		t.Error("Pointer in table diff does not point to expected value")
 	}
-	sd, err = NewSchemaDiff(&s2, &s1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sd = NewSchemaDiff(&s2, &s1)
 	if len(sd.TableDiffs) != 1 {
 		t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 	}
@@ -214,10 +193,7 @@ func TestSchemaDiffAlterTable(t *testing.T) {
 		t2 := aTable(to)
 		s1 := aSchema("s1", &t1)
 		s2 := aSchema("s2", &t2)
-		sd, err := NewSchemaDiff(&s1, &s2)
-		if err != nil {
-			t.Fatal(err)
-		}
+		sd := NewSchemaDiff(&s1, &s2)
 		if len(sd.TableDiffs) != 1 {
 			t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 		}
@@ -256,10 +232,7 @@ func TestSchemaDiffAlterTable(t *testing.T) {
 
 	// Helper for testing column adds or drops
 	getAlter := func(left, right *Schema) (TableDiff, TableAlterClause) {
-		sd, err := NewSchemaDiff(left, right)
-		if err != nil {
-			t.Fatal(err)
-		}
+		sd := NewSchemaDiff(left, right)
 		if len(sd.TableDiffs) != 1 {
 			t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 		}
@@ -310,10 +283,7 @@ func TestAlterTableStatementAllowUnsafeMods(t *testing.T) {
 	s2 := aSchema("s2", &t2)
 
 	getAlter := func(a, b *Schema) AlterTable {
-		sd, err := NewSchemaDiff(a, b)
-		if err != nil {
-			t.Fatal(err)
-		}
+		sd := NewSchemaDiff(a, b)
 		if len(sd.TableDiffs) != 1 {
 			t.Fatalf("Incorrect number of table diffs: expected 1, found %d", len(sd.TableDiffs))
 		}

--- a/index.go
+++ b/index.go
@@ -20,9 +20,6 @@ type Index struct {
 // Definition returns this index's definition clause, for use as part of a DDL
 // statement.
 func (idx *Index) Definition() string {
-	if idx == nil {
-		return ""
-	}
 	colParts := make([]string, len(idx.Columns))
 	for n := range idx.Columns {
 		if idx.SubParts[n] > 0 {

--- a/instance.go
+++ b/instance.go
@@ -21,18 +21,8 @@ type Instance struct {
 	Port           int
 	SocketPath     string
 	defaultParams  map[string]string
-	schemas        []*Schema
 	connectionPool map[string]*sqlx.DB // key is in format "schema?params" or just "schema" if no params
-	*sync.RWMutex                      // protects internal state
-}
-
-var allInstances struct {
-	sync.Mutex
-	byDSN map[string]*Instance
-}
-
-func init() {
-	allInstances.byDSN = make(map[string]*Instance)
+	*sync.RWMutex                      // protects connectionPool for concurrent operations
 }
 
 // NewInstance returns a pointer to a new Instance corresponding to the
@@ -57,28 +47,7 @@ func NewInstance(driver, dsn string) (*Instance, error) {
 		return nil, err
 	}
 
-	// See if an instance with the supplied dsn already exists. Note that we forbid
-	// creating a duplicate instance referring to the same underlying DB, as this
-	// would break caching logic around schema introspection.
-	// TODO: Remove caching logic, it causes more trouble than it's worth!
-	allInstances.Lock()
-	defer allInstances.Unlock()
-	instance, already := allInstances.byDSN[base]
-	if already {
-		// If the new DSN indicates use of a different user or pass, this is
-		// unsupported for now. If the DSN indicates use of different default
-		// params, use those for new connections going forwards.
-		// TODO: This is all temporary until the caching logic is removed altogether!
-		if instance.User != parsedConfig.User {
-			return nil, fmt.Errorf("Instance already exists, but with different username")
-		} else if instance.Password != parsedConfig.Passwd {
-			return nil, fmt.Errorf("Instance already exists, but with different password")
-		}
-		instance.defaultParams = params
-		return instance, nil
-	}
-
-	instance = &Instance{
+	instance := &Instance{
 		BaseDSN:        base,
 		Driver:         driver,
 		User:           parsedConfig.User,
@@ -101,7 +70,6 @@ func NewInstance(driver, dsn string) (*Instance, error) {
 		}
 	}
 
-	allInstances.byDSN[base] = instance
 	return instance, nil
 }
 
@@ -178,23 +146,30 @@ func (instance *Instance) CanConnect() (bool, error) {
 	return err == nil, err
 }
 
-// Schemas returns a slice of all schemas on the instance visible to the user.
-func (instance *Instance) Schemas() ([]*Schema, error) {
-	instance.RLock()
-	ret := instance.schemas
-	instance.RUnlock()
-	if ret != nil {
-		return ret, nil
-	}
-
+// SchemaNames returns a slice of all schema name strings on the instance
+// visible to the user. System schemas are excluded.
+func (instance *Instance) SchemaNames() ([]string, error) {
 	db, err := instance.Connect("information_schema", "")
 	if err != nil {
 		return nil, err
 	}
+	var result []string
+	query := `
+		SELECT schema_name
+		FROM   schemata
+		WHERE  schema_name NOT IN ('information_schema', 'performance_schema', 'mysql', 'test', 'sys')`
+	if err := db.Select(&result, query); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
-	instance.Lock()
-	defer instance.Unlock()
-
+// Schemas returns a slice of all schemas on the instance visible to the user.
+func (instance *Instance) Schemas() ([]*Schema, error) {
+	db, err := instance.Connect("information_schema", "")
+	if err != nil {
+		return nil, err
+	}
 	var rawSchemas []struct {
 		Name      string `db:"schema_name"`
 		CharSet   string `db:"default_character_set_name"`
@@ -208,16 +183,20 @@ func (instance *Instance) Schemas() ([]*Schema, error) {
 		return nil, err
 	}
 
-	instance.schemas = make([]*Schema, len(rawSchemas))
+	schemas := make([]*Schema, len(rawSchemas))
 	for n, rawSchema := range rawSchemas {
-		instance.schemas[n] = &Schema{
+		tables, err := instance.querySchemaTables(rawSchema.Name)
+		if err != nil {
+			return nil, err
+		}
+		schemas[n] = &Schema{
 			Name:      rawSchema.Name,
 			CharSet:   rawSchema.CharSet,
 			Collation: rawSchema.Collation,
-			instance:  instance,
+			Tables:    tables,
 		}
 	}
-	return instance.schemas, nil
+	return schemas, nil
 }
 
 // SchemasByName returns a map of schema name string to *Schema, for all schemas
@@ -234,26 +213,65 @@ func (instance *Instance) SchemasByName() (map[string]*Schema, error) {
 	return result, nil
 }
 
-// Schema returns a single schema by name.
+// Schema returns a single schema by name. If the schema does not exist, nil
+// will be returned along with a sql.ErrNoRows error.
 func (instance *Instance) Schema(name string) (*Schema, error) {
-	byName, err := instance.SchemasByName()
+	db, err := instance.Connect("information_schema", "")
 	if err != nil {
 		return nil, err
 	}
-	return byName[name], nil
+	var rawSchema struct {
+		Name      string `db:"schema_name"`
+		CharSet   string `db:"default_character_set_name"`
+		Collation string `db:"default_collation_name"`
+	}
+	query := `
+		SELECT schema_name, default_character_set_name, default_collation_name
+		FROM   schemata
+		WHERE  schema_name = ?`
+	if err := db.Get(&rawSchema, query, name); err != nil {
+		return nil, err
+	}
+	tables, err := instance.querySchemaTables(name)
+	if err != nil {
+		return nil, err
+	}
+	return &Schema{
+		Name:      rawSchema.Name,
+		CharSet:   rawSchema.CharSet,
+		Collation: rawSchema.Collation,
+		Tables:    tables,
+	}, nil
 }
 
 // HasSchema returns true if this instance has a schema with the supplied name
-// visible to the user, or false otherwise.
-func (instance *Instance) HasSchema(name string) bool {
-	s, _ := instance.Schema(name)
-	return s != nil
+// visible to the user, or false otherwise. An error result will only be
+// returned if a connection or query failed entirely and we weren't able to
+// determine whether the schema exists.
+func (instance *Instance) HasSchema(name string) (bool, error) {
+	db, err := instance.Connect("information_schema", "")
+	if err != nil {
+		return false, err
+	}
+	var exists int
+	query := `
+		SELECT 1
+		FROM   schemata
+		WHERE  schema_name = ?`
+	err = db.Get(&exists, query, name)
+	if err == nil {
+		return true, nil
+	} else if err == sql.ErrNoRows {
+		return false, nil
+	} else {
+		return false, err
+	}
 }
 
 // ShowCreateTable returns a string with a CREATE TABLE statement, representing
 // how the instance views the specified table as having been created.
-func (instance *Instance) ShowCreateTable(schema *Schema, table *Table) (string, error) {
-	db, err := instance.Connect(schema.Name, "")
+func (instance *Instance) ShowCreateTable(schema, table string) (string, error) {
+	db, err := instance.Connect(schema, "")
 	if err != nil {
 		return "", err
 	}
@@ -262,7 +280,7 @@ func (instance *Instance) ShowCreateTable(schema *Schema, table *Table) (string,
 		TableName       string `db:"Table"`
 		CreateStatement string `db:"Create Table"`
 	}
-	query := fmt.Sprintf("SHOW CREATE TABLE %s", EscapeIdentifier(table.Name))
+	query := fmt.Sprintf("SHOW CREATE TABLE %s", EscapeIdentifier(table))
 	if err := db.Select(&createRows, query); err != nil {
 		return "", err
 	}
@@ -278,7 +296,7 @@ func (instance *Instance) ShowCreateTable(schema *Schema, table *Table) (string,
 // the error will be sql.ErrNoRows.
 // Please note that use of innodb_stats_persistent may negatively impact the
 // accuracy. For example, see https://bugs.mysql.com/bug.php?id=75428.
-func (instance *Instance) TableSize(schema *Schema, table *Table) (int64, error) {
+func (instance *Instance) TableSize(schema, table string) (int64, error) {
 	var result int64
 	db, err := instance.Connect("information_schema", "")
 	if err != nil {
@@ -288,30 +306,24 @@ func (instance *Instance) TableSize(schema *Schema, table *Table) (int64, error)
 		SELECT  data_length + index_length + data_free
 		FROM    tables
 		WHERE   table_schema = ? and table_name = ?`,
-		schema.Name, table.Name)
+		schema, table)
 	return result, err
 }
 
 // TableHasRows returns true if the table has at least one row. If an error
 // occurs in querying, also returns true (along with the error) since a false
 // positive is generally less dangerous in this case than a false negative.
-func (instance *Instance) TableHasRows(schema *Schema, table *Table) (bool, error) {
-	db, err := instance.Connect(schema.Name, "")
+func (instance *Instance) TableHasRows(schema, table string) (bool, error) {
+	db, err := instance.Connect(schema, "")
 	if err != nil {
 		return true, err
 	}
 	var result []int
-	query := fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", EscapeIdentifier(table.Name))
+	query := fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", EscapeIdentifier(table))
 	if err := db.Select(&result, query); err != nil {
 		return true, err
 	}
 	return len(result) != 0, nil
-}
-
-func (instance *Instance) purgeSchemaCache() {
-	instance.Lock()
-	instance.schemas = nil
-	instance.Unlock()
 }
 
 // CreateSchema creates a new database schema with the supplied name, and
@@ -331,31 +343,32 @@ func (instance *Instance) CreateSchema(name, charSet, collation string) (*Schema
 	if err != nil {
 		return nil, err
 	}
-
-	// Purge schema cache; next call to Schema will repopulate
-	instance.purgeSchemaCache()
 	return instance.Schema(name)
 }
 
 // DropSchema first drops all tables in the schema, and then drops the database
 // schema itself. If onlyIfEmpty==true, returns an error if any of the tables
 // have any rows.
-func (instance *Instance) DropSchema(schema *Schema, onlyIfEmpty bool) error {
+func (instance *Instance) DropSchema(schema string, onlyIfEmpty bool) error {
 	err := instance.DropTablesInSchema(schema, onlyIfEmpty)
 	if err != nil {
 		return err
 	}
 
-	db, err := instance.Connect(schema.Name, "")
+	s, err := instance.Schema(schema)
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec(schema.DropStatement())
+	db, err := instance.Connect("", "")
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec(s.DropStatement())
 	if err != nil {
 		return err
 	}
 
-	prefix := fmt.Sprintf("%s?", schema.Name)
+	prefix := fmt.Sprintf("%s?", schema)
 	instance.Lock()
 	for key, connPool := range instance.connectionPool {
 		if strings.HasPrefix(key, prefix) {
@@ -364,9 +377,6 @@ func (instance *Instance) DropSchema(schema *Schema, onlyIfEmpty bool) error {
 		}
 	}
 	instance.Unlock()
-
-	// Purge schema cache; next call to Schema will repopulate
-	instance.purgeSchemaCache()
 	return nil
 }
 
@@ -375,62 +385,54 @@ func (instance *Instance) DropSchema(schema *Schema, onlyIfEmpty bool) error {
 // collation, or supply an empty string for newCollation to use the default
 // collation of newCharSet. (Supplying an empty string for both is also allowed,
 // but is a no-op.)
-func (instance *Instance) AlterSchema(schema *Schema, newCharSet, newCollation string) error {
-	db, err := instance.Connect(schema.Name, "")
+func (instance *Instance) AlterSchema(schema, newCharSet, newCollation string) error {
+	s, err := instance.Schema(schema)
 	if err != nil {
 		return err
 	}
-	statement := schema.AlterStatement(newCharSet, newCollation)
+	statement := s.AlterStatement(newCharSet, newCollation)
 	if statement == "" {
 		return nil
+	}
+	db, err := instance.Connect("", "")
+	if err != nil {
+		return err
 	}
 	if _, err = db.Exec(statement); err != nil {
 		return err
 	}
-
-	// Purge schema cache, so that the call to Schema will repopulate with new
-	// charset and collation. (We can't just set them directly without querying
-	// since default-collation-for-charset info is handled by the database.)
-	instance.purgeSchemaCache()
-	alteredSchema, err := instance.Schema(schema.Name)
-	if err == nil {
-		*schema = *alteredSchema
-	}
-	return err
+	return nil
 }
 
 // DropTablesInSchema drops all tables in a schema. If onlyIfEmpty==true,
 // returns an error if any of the tables have any rows.
-func (instance *Instance) DropTablesInSchema(schema *Schema, onlyIfEmpty bool) error {
-	db, err := instance.Connect(schema.Name, "foreign_key_checks=0")
+func (instance *Instance) DropTablesInSchema(schema string, onlyIfEmpty bool) error {
+	s, err := instance.Schema(schema)
 	if err != nil {
 		return err
 	}
-	tables, err := schema.Tables()
-	if err != nil {
-		return err
-	}
-
 	if onlyIfEmpty {
-		for _, t := range tables {
-			hasRows, err := instance.TableHasRows(schema, t)
+		for _, t := range s.Tables {
+			hasRows, err := instance.TableHasRows(schema, t.Name)
 			if err != nil {
 				return err
 			}
 			if hasRows {
-				return fmt.Errorf("DropTablesInSchema: table %s.%s has at least one row", EscapeIdentifier(schema.Name), EscapeIdentifier(t.Name))
+				return fmt.Errorf("DropTablesInSchema: table %s.%s has at least one row", EscapeIdentifier(schema), EscapeIdentifier(t.Name))
 			}
 		}
 	}
 
-	for _, t := range tables {
+	db, err := instance.Connect(schema, "foreign_key_checks=0")
+	if err != nil {
+		return err
+	}
+	for _, t := range s.Tables {
 		_, err := db.Exec(t.DropStatement())
 		if err != nil {
 			return err
 		}
 	}
-
-	schema.PurgeTableCache()
 	return nil
 }
 
@@ -438,22 +440,21 @@ func (instance *Instance) DropTablesInSchema(schema *Schema, onlyIfEmpty bool) e
 // Ideally dest should be an empty schema, or at least be pre-verified for not
 // having existing tables with conflicting names, but this is the caller's
 // responsibility to confirm.
-func (instance *Instance) CloneSchema(src, dest *Schema) error {
-	db, err := instance.Connect(dest.Name, "foreign_key_checks=0")
+func (instance *Instance) CloneSchema(src, dest string) error {
+	s, err := instance.Schema(src)
 	if err != nil {
 		return err
 	}
-	tables, err := src.Tables()
+	db, err := instance.Connect(dest, "foreign_key_checks=0")
 	if err != nil {
 		return err
 	}
-	for _, t := range tables {
+	for _, t := range s.Tables {
 		_, err := db.Exec(t.CreateStatement())
 		if err != nil {
 			return err
 		}
 	}
-	dest.PurgeTableCache()
 	return nil
 }
 
@@ -466,6 +467,228 @@ func (instance *Instance) DefaultCharSetAndCollation() (serverCharSet, serverCol
 	}
 	err = db.QueryRow("SELECT @@global.character_set_server, @@global.collation_server").Scan(&serverCharSet, &serverCollation)
 	return
+}
+
+func (instance *Instance) querySchemaTables(schema string) ([]*Table, error) {
+	db, err := instance.Connect("information_schema", "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Obtain the tables in the schema
+	var rawTables []struct {
+		Name               string         `db:"table_name"`
+		Type               string         `db:"table_type"`
+		Engine             sql.NullString `db:"engine"`
+		AutoIncrement      sql.NullInt64  `db:"auto_increment"`
+		TableCollation     sql.NullString `db:"table_collation"`
+		CreateOptions      sql.NullString `db:"create_options"`
+		Comment            string         `db:"table_comment"`
+		CharSet            string         `db:"character_set_name"`
+		CollationIsDefault string         `db:"is_default"`
+	}
+	query := `
+		SELECT t.table_name, t.table_type, t.engine, t.auto_increment, t.table_collation,
+		       UPPER(t.create_options) AS create_options, t.table_comment,
+		       c.character_set_name, c.is_default
+		FROM   tables t
+		JOIN   collations c ON t.table_collation = c.collation_name
+		WHERE  t.table_schema = ?
+		AND    t.table_type = 'BASE TABLE'`
+	if err := db.Select(&rawTables, query, schema); err != nil {
+		return nil, fmt.Errorf("Error querying information_schema.tables: %s", err)
+	}
+	tables := make([]*Table, len(rawTables))
+	for n, rawTable := range rawTables {
+		tables[n] = &Table{
+			Name:    rawTable.Name,
+			Engine:  rawTable.Engine.String,
+			CharSet: rawTable.CharSet,
+			Comment: rawTable.Comment,
+		}
+		if rawTable.CollationIsDefault == "" && rawTable.TableCollation.Valid {
+			tables[n].Collation = rawTable.TableCollation.String
+		}
+		if rawTable.AutoIncrement.Valid {
+			tables[n].NextAutoIncrement = uint64(rawTable.AutoIncrement.Int64)
+		}
+		if rawTable.CreateOptions.Valid && rawTable.CreateOptions.String != "" && rawTable.CreateOptions.String != "PARTITIONED" {
+			// information_schema.tables.create_options annoyingly contains "partitioned"
+			// if the table is partitioned, despite this not being present as-is in the
+			// table table definition. All other create_options are present verbatim.
+			// Currently in mysql-server/sql/sql_show.cc, it's always at the *end* of
+			// create_options... but just to code defensively we handle any location.
+			if strings.HasPrefix(rawTable.CreateOptions.String, "PARTITIONED ") {
+				tables[n].CreateOptions = strings.Replace(rawTable.CreateOptions.String, "PARTITIONED ", "", 1)
+			} else {
+				tables[n].CreateOptions = strings.Replace(rawTable.CreateOptions.String, " PARTITIONED", "", 1)
+			}
+		}
+	}
+
+	// Obtain the columns in all tables in the schema
+	var rawColumns []struct {
+		Name               string         `db:"column_name"`
+		TableName          string         `db:"table_name"`
+		Type               string         `db:"column_type"`
+		IsNullable         string         `db:"is_nullable"`
+		Default            sql.NullString `db:"column_default"`
+		Extra              string         `db:"extra"`
+		Comment            string         `db:"column_comment"`
+		CharSet            sql.NullString `db:"character_set_name"`
+		Collation          sql.NullString `db:"collation_name"`
+		CollationIsDefault sql.NullString `db:"is_default"`
+	}
+	query = `
+		SELECT    c.table_name, c.column_name, c.column_type, c.is_nullable, c.column_default,
+		          c.extra, c.column_comment, c.character_set_name, c.collation_name,
+		          co.is_default
+		FROM      columns c
+		LEFT JOIN collations co ON co.collation_name = c.collation_name
+		WHERE     c.table_schema = ?
+		ORDER BY  c.table_name, c.ordinal_position`
+	if err := db.Select(&rawColumns, query, schema); err != nil {
+		return nil, fmt.Errorf("Error querying information_schema.columns: %s", err)
+	}
+	columnsByTableName := make(map[string][]*Column)
+	columnsByTableAndName := make(map[string]*Column)
+	for _, rawColumn := range rawColumns {
+		col := &Column{
+			Name:          rawColumn.Name,
+			TypeInDB:      rawColumn.Type,
+			Nullable:      strings.ToUpper(rawColumn.IsNullable) == "YES",
+			AutoIncrement: strings.Contains(rawColumn.Extra, "auto_increment"),
+			Comment:       rawColumn.Comment,
+		}
+		if !rawColumn.Default.Valid {
+			col.Default = ColumnDefaultNull
+		} else if strings.HasPrefix(rawColumn.Default.String, "CURRENT_TIMESTAMP") && (strings.HasPrefix(rawColumn.Type, "timestamp") || strings.HasPrefix(rawColumn.Type, "datetime")) {
+			col.Default = ColumnDefaultExpression(rawColumn.Default.String)
+		} else if strings.HasPrefix(rawColumn.Type, "bit") && strings.HasPrefix(rawColumn.Default.String, "b'") {
+			col.Default = ColumnDefaultExpression(rawColumn.Default.String)
+		} else {
+			col.Default = ColumnDefaultValue(rawColumn.Default.String)
+		}
+		if strings.HasPrefix(strings.ToLower(rawColumn.Extra), "on update ") {
+			// MariaDB strips fractional second precision here but includes it in SHOW
+			// CREATE TABLE. MySQL includes it in both places. Here we adjust the MariaDB
+			// one to look like MySQL, so that our generated DDL matches SHOW CREATE TABLE.
+			if openParen := strings.IndexByte(rawColumn.Type, '('); openParen > -1 && !strings.Contains(strings.ToLower(rawColumn.Extra), "current_timestamp(") {
+				col.OnUpdate = fmt.Sprintf("%s%s", strings.ToUpper(rawColumn.Extra[10:]), rawColumn.Type[openParen:])
+			} else {
+				col.OnUpdate = strings.ToUpper(rawColumn.Extra[10:])
+			}
+		}
+		if rawColumn.Collation.Valid { // only text-based column types have a notion of charset and collation
+			col.CharSet = rawColumn.CharSet.String
+			if rawColumn.CollationIsDefault.String == "" {
+				// SHOW CREATE TABLE only includes col's collation if it differs from col's charset's default collation
+				col.Collation = rawColumn.Collation.String
+			}
+		}
+		if columnsByTableName[rawColumn.TableName] == nil {
+			columnsByTableName[rawColumn.TableName] = make([]*Column, 0)
+		}
+		columnsByTableName[rawColumn.TableName] = append(columnsByTableName[rawColumn.TableName], col)
+		fullNameStr := fmt.Sprintf("%s.%s.%s", schema, rawColumn.TableName, rawColumn.Name)
+		columnsByTableAndName[fullNameStr] = col
+	}
+	for n, t := range tables {
+		tables[n].Columns = columnsByTableName[t.Name]
+	}
+
+	// Obtain the indexes of all tables in the schema. Since multi-column indexes
+	// have multiple rows in the result set, we do two passes over the result: one
+	// to figure out which indexes exist, and one to stitch together the col info.
+	// We cannot use an ORDER BY on this query, since only the unsorted result
+	// matches the same order of secondary indexes as the CREATE TABLE statement.
+	var rawIndexes []struct {
+		Name       string         `db:"index_name"`
+		TableName  string         `db:"table_name"`
+		NonUnique  uint8          `db:"non_unique"`
+		SeqInIndex uint8          `db:"seq_in_index"`
+		ColumnName string         `db:"column_name"`
+		SubPart    sql.NullInt64  `db:"sub_part"`
+		Comment    sql.NullString `db:"index_comment"`
+	}
+	query = `
+		SELECT   index_name, table_name, non_unique, seq_in_index, column_name,
+		         sub_part, index_comment
+		FROM     statistics
+		WHERE    table_schema = ?`
+	if err := db.Select(&rawIndexes, query, schema); err != nil {
+		return nil, fmt.Errorf("Error querying information_schema.statistics: %s", err)
+	}
+	primaryKeyByTableName := make(map[string]*Index)
+	secondaryIndexesByTableName := make(map[string][]*Index)
+	indexesByTableAndName := make(map[string]*Index)
+	for _, rawIndex := range rawIndexes {
+		if rawIndex.SeqInIndex > 1 {
+			continue
+		}
+		index := &Index{
+			Name:     rawIndex.Name,
+			Unique:   rawIndex.NonUnique == 0,
+			Columns:  make([]*Column, 0),
+			SubParts: make([]uint16, 0),
+			Comment:  rawIndex.Comment.String,
+		}
+		if strings.ToUpper(index.Name) == "PRIMARY" {
+			primaryKeyByTableName[rawIndex.TableName] = index
+			index.PrimaryKey = true
+		} else {
+			if secondaryIndexesByTableName[rawIndex.TableName] == nil {
+				secondaryIndexesByTableName[rawIndex.TableName] = make([]*Index, 0)
+			}
+			secondaryIndexesByTableName[rawIndex.TableName] = append(secondaryIndexesByTableName[rawIndex.TableName], index)
+		}
+		fullNameStr := fmt.Sprintf("%s.%s.%s", schema, rawIndex.TableName, rawIndex.Name)
+		indexesByTableAndName[fullNameStr] = index
+	}
+	for _, rawIndex := range rawIndexes {
+		fullIndexNameStr := fmt.Sprintf("%s.%s.%s", schema, rawIndex.TableName, rawIndex.Name)
+		index, ok := indexesByTableAndName[fullIndexNameStr]
+		if !ok {
+			panic(fmt.Errorf("Cannot find index %s", fullIndexNameStr))
+		}
+		fullColNameStr := fmt.Sprintf("%s.%s.%s", schema, rawIndex.TableName, rawIndex.ColumnName)
+		col, ok := columnsByTableAndName[fullColNameStr]
+		if !ok {
+			panic(fmt.Errorf("Cannot find indexed column %s for index %s", fullColNameStr, fullIndexNameStr))
+		}
+		for len(index.Columns) < int(rawIndex.SeqInIndex) {
+			index.Columns = append(index.Columns, new(Column))
+		}
+		index.Columns[rawIndex.SeqInIndex-1] = col
+		if rawIndex.SubPart.Valid {
+			index.SubParts = append(index.SubParts, uint16(rawIndex.SubPart.Int64))
+		} else {
+			index.SubParts = append(index.SubParts, 0)
+		}
+	}
+	for _, t := range tables {
+		t.PrimaryKey = primaryKeyByTableName[t.Name]
+		t.SecondaryIndexes = secondaryIndexesByTableName[t.Name]
+	}
+
+	// Obtain actual SHOW CREATE TABLE output and store in each table. Compare
+	// with what we expect the create DDL to be, to determine if we support
+	// diffing for the table. Ignore next-auto-increment differences in this
+	// comparison, since the value may have changed between our previous
+	// information_schema introspection and our current SHOW CREATE TABLE call!
+	for _, t := range tables {
+		t.createStatement, err = instance.ShowCreateTable(schema, t.Name)
+		if err != nil {
+			return nil, fmt.Errorf("Error executing SHOW CREATE TABLE: %s", err)
+		}
+		beforeTable, _ := ParseCreateAutoInc(t.createStatement)
+		afterTable, _ := ParseCreateAutoInc(t.GeneratedCreateStatement())
+		if beforeTable != afterTable {
+			t.UnsupportedDDL = true
+		}
+	}
+
+	return tables, nil
 }
 
 // baseDSN returns a DSN with the database (schema) name and params stripped.

--- a/instance.go
+++ b/instance.go
@@ -450,7 +450,7 @@ func (instance *Instance) CloneSchema(src, dest string) error {
 		return err
 	}
 	for _, t := range s.Tables {
-		_, err := db.Exec(t.CreateStatement())
+		_, err := db.Exec(t.CreateStatement)
 		if err != nil {
 			return err
 		}
@@ -677,11 +677,11 @@ func (instance *Instance) querySchemaTables(schema string) ([]*Table, error) {
 	// comparison, since the value may have changed between our previous
 	// information_schema introspection and our current SHOW CREATE TABLE call!
 	for _, t := range tables {
-		t.createStatement, err = instance.ShowCreateTable(schema, t.Name)
+		t.CreateStatement, err = instance.ShowCreateTable(schema, t.Name)
 		if err != nil {
 			return nil, fmt.Errorf("Error executing SHOW CREATE TABLE: %s", err)
 		}
-		beforeTable, _ := ParseCreateAutoInc(t.createStatement)
+		beforeTable, _ := ParseCreateAutoInc(t.CreateStatement)
 		afterTable, _ := ParseCreateAutoInc(t.GeneratedCreateStatement())
 		if beforeTable != afterTable {
 			t.UnsupportedDDL = true

--- a/instance_test.go
+++ b/instance_test.go
@@ -199,12 +199,12 @@ func (s TengoIntegrationSuite) TestInstanceShowCreateTable(t *testing.T) {
 	}
 
 	t1expected := aTable(1)
-	if t1create != t1expected.createStatement {
-		t.Errorf("Mismatch for SHOW CREATE TABLE\nActual return from %s:\n%s\n----------\nExpected output: %s", s.d.Image, t1create, t1expected.createStatement)
+	if t1create != t1expected.CreateStatement {
+		t.Errorf("Mismatch for SHOW CREATE TABLE\nActual return from %s:\n%s\n----------\nExpected output: %s", s.d.Image, t1create, t1expected.CreateStatement)
 	}
 	t2expected := anotherTable()
-	if t2create != t2expected.createStatement {
-		t.Errorf("Mismatch for SHOW CREATE TABLE\nActual return from %s:\n%s\n----------\nExpected output: %s", s.d.Image, t2create, t2expected.createStatement)
+	if t2create != t2expected.CreateStatement {
+		t.Errorf("Mismatch for SHOW CREATE TABLE\nActual return from %s:\n%s\n----------\nExpected output: %s", s.d.Image, t2create, t2expected.CreateStatement)
 	}
 
 	// Test nonexistent table

--- a/schema.go
+++ b/schema.go
@@ -1,10 +1,8 @@
 package tengo
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 )
 
 // Schema represents a database schema.
@@ -12,287 +10,41 @@ type Schema struct {
 	Name      string
 	CharSet   string
 	Collation string
-	tables    []*Table
-	instance  *Instance
+	Tables    []*Table
 }
 
 // TablesByName returns a mapping of table names to Table struct values, for
 // all tables in the schema.
-func (s *Schema) TablesByName() (map[string]*Table, error) {
-	tables, err := s.Tables()
-	if err != nil {
-		return nil, err
+func (s *Schema) TablesByName() map[string]*Table {
+	if s == nil {
+		return map[string]*Table{}
 	}
-	result := make(map[string]*Table, len(tables))
-	for _, t := range tables {
+	result := make(map[string]*Table, len(s.Tables))
+	for _, t := range s.Tables {
 		result[t.Name] = t
 	}
-	return result, nil
+	return result
 }
 
 // HasTable returns true if a table with the given name exists in the schema.
 func (s *Schema) HasTable(name string) bool {
-	t, err := s.Table(name)
-	return (err == nil && t != nil)
+	return s != nil && s.Table(name) != nil
 }
 
 // Table returns a table by name.
-func (s *Schema) Table(name string) (*Table, error) {
-	if s == nil {
-		return nil, nil
-	}
-	byName, err := s.TablesByName()
-	if err != nil {
-		return nil, err
-	}
-	return byName[name], nil
-}
-
-// Tables returns a slice of all tables in the schema.
-func (s *Schema) Tables() ([]*Table, error) {
-	if s == nil {
-		return []*Table{}, nil
-	}
-	if s.tables != nil {
-		return s.tables, nil
-	}
-	if s.instance == nil {
-		return nil, fmt.Errorf("Schema.Tables: schema %s has been detached from its instance", s.Name)
-	}
-
-	db, err := s.instance.Connect("information_schema", "")
-	if err != nil {
-		return nil, err
-	}
-
-	// Obtain the tables in the schema
-	var rawTables []struct {
-		Name               string         `db:"table_name"`
-		Type               string         `db:"table_type"`
-		Engine             sql.NullString `db:"engine"`
-		AutoIncrement      sql.NullInt64  `db:"auto_increment"`
-		TableCollation     sql.NullString `db:"table_collation"`
-		CreateOptions      sql.NullString `db:"create_options"`
-		Comment            string         `db:"table_comment"`
-		CharSet            string         `db:"character_set_name"`
-		CollationIsDefault string         `db:"is_default"`
-	}
-	query := `
-		SELECT t.table_name, t.table_type, t.engine, t.auto_increment, t.table_collation,
-		       UPPER(t.create_options) AS create_options, t.table_comment,
-		       c.character_set_name, c.is_default
-		FROM   tables t
-		JOIN   collations c ON t.table_collation = c.collation_name
-		WHERE  t.table_schema = ?
-		AND    t.table_type = 'BASE TABLE'`
-	if err := db.Select(&rawTables, query, s.Name); err != nil {
-		return nil, fmt.Errorf("Error querying information_schema.tables: %s", err)
-	}
-
-	s.tables = make([]*Table, len(rawTables))
-	for n, rawTable := range rawTables {
-		s.tables[n] = &Table{
-			Name:    rawTable.Name,
-			Engine:  rawTable.Engine.String,
-			CharSet: rawTable.CharSet,
-			Comment: rawTable.Comment,
-		}
-		if rawTable.CollationIsDefault == "" && rawTable.TableCollation.Valid {
-			s.tables[n].Collation = rawTable.TableCollation.String
-		}
-		if rawTable.AutoIncrement.Valid {
-			s.tables[n].NextAutoIncrement = uint64(rawTable.AutoIncrement.Int64)
-		}
-		if rawTable.CreateOptions.Valid && rawTable.CreateOptions.String != "" && rawTable.CreateOptions.String != "PARTITIONED" {
-			// information_schema.tables.create_options annoyingly contains "partitioned"
-			// if the table is partitioned, despite this not being present as-is in the
-			// table table definition. All other create_options are present verbatim.
-			// Currently in mysql-server/sql/sql_show.cc, it's always at the *end* of
-			// create_options... but just to code defensively we handle any location.
-			if strings.HasPrefix(rawTable.CreateOptions.String, "PARTITIONED ") {
-				s.tables[n].CreateOptions = strings.Replace(rawTable.CreateOptions.String, "PARTITIONED ", "", 1)
-			} else {
-				s.tables[n].CreateOptions = strings.Replace(rawTable.CreateOptions.String, " PARTITIONED", "", 1)
+func (s *Schema) Table(name string) *Table {
+	if s != nil {
+		for _, t := range s.Tables {
+			if t.Name == name {
+				return t
 			}
 		}
 	}
-
-	// Obtain the columns in all tables in the schema
-	var rawColumns []struct {
-		Name               string         `db:"column_name"`
-		TableName          string         `db:"table_name"`
-		Type               string         `db:"column_type"`
-		IsNullable         string         `db:"is_nullable"`
-		Default            sql.NullString `db:"column_default"`
-		Extra              string         `db:"extra"`
-		Comment            string         `db:"column_comment"`
-		CharSet            sql.NullString `db:"character_set_name"`
-		Collation          sql.NullString `db:"collation_name"`
-		CollationIsDefault sql.NullString `db:"is_default"`
-	}
-	query = `
-		SELECT    c.table_name, c.column_name, c.column_type, c.is_nullable, c.column_default,
-		          c.extra, c.column_comment, c.character_set_name, c.collation_name,
-		          co.is_default
-		FROM      columns c
-		LEFT JOIN collations co ON co.collation_name = c.collation_name
-		WHERE     c.table_schema = ?
-		ORDER BY  c.table_name, c.ordinal_position`
-	if err := db.Select(&rawColumns, query, s.Name); err != nil {
-		return nil, fmt.Errorf("Error querying information_schema.columns: %s", err)
-	}
-	columnsByTableName := make(map[string][]*Column)
-	columnsByTableAndName := make(map[string]*Column)
-	for _, rawColumn := range rawColumns {
-		col := &Column{
-			Name:          rawColumn.Name,
-			TypeInDB:      rawColumn.Type,
-			Nullable:      strings.ToUpper(rawColumn.IsNullable) == "YES",
-			AutoIncrement: strings.Contains(rawColumn.Extra, "auto_increment"),
-			Comment:       rawColumn.Comment,
-		}
-		if !rawColumn.Default.Valid {
-			col.Default = ColumnDefaultNull
-		} else if strings.HasPrefix(rawColumn.Default.String, "CURRENT_TIMESTAMP") && (strings.HasPrefix(rawColumn.Type, "timestamp") || strings.HasPrefix(rawColumn.Type, "datetime")) {
-			col.Default = ColumnDefaultExpression(rawColumn.Default.String)
-		} else if strings.HasPrefix(rawColumn.Type, "bit") && strings.HasPrefix(rawColumn.Default.String, "b'") {
-			col.Default = ColumnDefaultExpression(rawColumn.Default.String)
-		} else {
-			col.Default = ColumnDefaultValue(rawColumn.Default.String)
-		}
-		if strings.HasPrefix(strings.ToLower(rawColumn.Extra), "on update ") {
-			// MariaDB strips fractional second precision here but includes it in SHOW
-			// CREATE TABLE. MySQL includes it in both places. Here we adjust the MariaDB
-			// one to look like MySQL, so that our generated DDL matches SHOW CREATE TABLE.
-			if openParen := strings.IndexByte(rawColumn.Type, '('); openParen > -1 && !strings.Contains(strings.ToLower(rawColumn.Extra), "current_timestamp(") {
-				col.OnUpdate = fmt.Sprintf("%s%s", strings.ToUpper(rawColumn.Extra[10:]), rawColumn.Type[openParen:])
-			} else {
-				col.OnUpdate = strings.ToUpper(rawColumn.Extra[10:])
-			}
-		}
-		if rawColumn.Collation.Valid { // only text-based column types have a notion of charset and collation
-			col.CharSet = rawColumn.CharSet.String
-			if rawColumn.CollationIsDefault.String == "" {
-				// SHOW CREATE TABLE only includes col's collation if it differs from col's charset's default collation
-				col.Collation = rawColumn.Collation.String
-			}
-		}
-		if columnsByTableName[rawColumn.TableName] == nil {
-			columnsByTableName[rawColumn.TableName] = make([]*Column, 0)
-		}
-		columnsByTableName[rawColumn.TableName] = append(columnsByTableName[rawColumn.TableName], col)
-		fullNameStr := fmt.Sprintf("%s.%s.%s", s.Name, rawColumn.TableName, rawColumn.Name)
-		columnsByTableAndName[fullNameStr] = col
-	}
-	for n, t := range s.tables {
-		s.tables[n].Columns = columnsByTableName[t.Name]
-	}
-
-	// Obtain the indexes of all tables in the schema. Since multi-column indexes
-	// have multiple rows in the result set, we do two passes over the result: one
-	// to figure out which indexes exist, and one to stitch together the col info.
-	// We cannot use an ORDER BY on this query, since only the unsorted result
-	// matches the same order of secondary indexes as the CREATE TABLE statement.
-	var rawIndexes []struct {
-		Name       string         `db:"index_name"`
-		TableName  string         `db:"table_name"`
-		NonUnique  uint8          `db:"non_unique"`
-		SeqInIndex uint8          `db:"seq_in_index"`
-		ColumnName string         `db:"column_name"`
-		SubPart    sql.NullInt64  `db:"sub_part"`
-		Comment    sql.NullString `db:"index_comment"`
-	}
-	query = `
-		SELECT   index_name, table_name, non_unique, seq_in_index, column_name,
-		         sub_part, index_comment
-		FROM     statistics
-		WHERE    table_schema = ?`
-	if err := db.Select(&rawIndexes, query, s.Name); err != nil {
-		return nil, fmt.Errorf("Error querying information_schema.statistics: %s", err)
-	}
-	primaryKeyByTableName := make(map[string]*Index)
-	secondaryIndexesByTableName := make(map[string][]*Index)
-	indexesByTableAndName := make(map[string]*Index)
-	for _, rawIndex := range rawIndexes {
-		if rawIndex.SeqInIndex > 1 {
-			continue
-		}
-		index := &Index{
-			Name:     rawIndex.Name,
-			Unique:   rawIndex.NonUnique == 0,
-			Columns:  make([]*Column, 0),
-			SubParts: make([]uint16, 0),
-			Comment:  rawIndex.Comment.String,
-		}
-		if strings.ToUpper(index.Name) == "PRIMARY" {
-			primaryKeyByTableName[rawIndex.TableName] = index
-			index.PrimaryKey = true
-		} else {
-			if secondaryIndexesByTableName[rawIndex.TableName] == nil {
-				secondaryIndexesByTableName[rawIndex.TableName] = make([]*Index, 0)
-			}
-			secondaryIndexesByTableName[rawIndex.TableName] = append(secondaryIndexesByTableName[rawIndex.TableName], index)
-		}
-		fullNameStr := fmt.Sprintf("%s.%s.%s", s.Name, rawIndex.TableName, rawIndex.Name)
-		indexesByTableAndName[fullNameStr] = index
-	}
-	for _, rawIndex := range rawIndexes {
-		fullIndexNameStr := fmt.Sprintf("%s.%s.%s", s.Name, rawIndex.TableName, rawIndex.Name)
-		index, ok := indexesByTableAndName[fullIndexNameStr]
-		if !ok {
-			panic(fmt.Errorf("Cannot find index %s", fullIndexNameStr))
-		}
-		fullColNameStr := fmt.Sprintf("%s.%s.%s", s.Name, rawIndex.TableName, rawIndex.ColumnName)
-		col, ok := columnsByTableAndName[fullColNameStr]
-		if !ok {
-			panic(fmt.Errorf("Cannot find indexed column %s for index %s", fullColNameStr, fullIndexNameStr))
-		}
-		for len(index.Columns) < int(rawIndex.SeqInIndex) {
-			index.Columns = append(index.Columns, new(Column))
-		}
-		index.Columns[rawIndex.SeqInIndex-1] = col
-		if rawIndex.SubPart.Valid {
-			index.SubParts = append(index.SubParts, uint16(rawIndex.SubPart.Int64))
-		} else {
-			index.SubParts = append(index.SubParts, 0)
-		}
-	}
-	for _, t := range s.tables {
-		t.PrimaryKey = primaryKeyByTableName[t.Name]
-		t.SecondaryIndexes = secondaryIndexesByTableName[t.Name]
-	}
-
-	// Obtain actual SHOW CREATE TABLE output and store in each table. Compare
-	// with what we expect the create DDL to be, to determine if we support
-	// diffing for the table. Ignore next-auto-increment differences in this
-	// comparison, since the value may have changed between our previous
-	// information_schema introspection and our current SHOW CREATE TABLE call!
-	for _, t := range s.tables {
-		t.createStatement, err = s.instance.ShowCreateTable(s, t)
-		if err != nil {
-			return nil, fmt.Errorf("Error executing SHOW CREATE TABLE: %s", err)
-		}
-		beforeTable, _ := ParseCreateAutoInc(t.createStatement)
-		afterTable, _ := ParseCreateAutoInc(t.GeneratedCreateStatement())
-		if beforeTable != afterTable {
-			t.UnsupportedDDL = true
-		}
-	}
-
-	return s.tables, nil
-}
-
-// PurgeTableCache purges any previously-cached table information. This should
-// be used after creating, altering, renaming, or dropping tables.
-func (s *Schema) PurgeTableCache() {
-	if s == nil || s.instance == nil {
-		return
-	}
-	s.tables = nil
+	return nil
 }
 
 // Diff returns the set of differences between this schema and another schema.
-func (s *Schema) Diff(other *Schema) (*SchemaDiff, error) {
+func (s *Schema) Diff(other *Schema) *SchemaDiff {
 	return NewSchemaDiff(s, other)
 }
 
@@ -336,19 +88,16 @@ func (s *Schema) AlterStatement(charSet, collation string) string {
 }
 
 // OverridesServerCharSet checks if the schema's default character set and
-// collation differ from its instance's server-level default character set
+// collation differ from an instance's server-level default character set
 // and collation. The first return value will be true if the schema's charset
-// differs from its instance's; the second return value will be true if the
-// schema's collation differs from its instance's.
-func (s *Schema) OverridesServerCharSet() (overridesCharSet bool, overridesCollation bool, err error) {
+// differs from the instance's; the second return value will be true if the
+// schema's collation differs from the instance's.
+func (s *Schema) OverridesServerCharSet(instance *Instance) (overridesCharSet bool, overridesCollation bool, err error) {
 	if s == nil {
 		return false, false, errors.New("Attempted to check character set and collation on a nil schema")
 	}
-	if s.instance == nil {
-		return false, false, fmt.Errorf("Attempted to check character set and collation on schema %s which has been detached from its instance", s.Name)
-	}
 
-	serverCharSet, serverCollation, err := s.instance.DefaultCharSetAndCollation()
+	serverCharSet, serverCollation, err := instance.DefaultCharSetAndCollation()
 	if err != nil {
 		return false, false, err
 	}
@@ -359,28 +108,4 @@ func (s *Schema) OverridesServerCharSet() (overridesCharSet bool, overridesColla
 		return false, true, nil
 	}
 	return false, false, nil
-}
-
-// CachedCopy returns a copy of the Schema object without its instance
-// association. This copy may be used in diff operations even if the original
-// schema it was copied from is dropped from its instance.
-func (s *Schema) CachedCopy() (*Schema, error) {
-	if s == nil {
-		return nil, nil
-	}
-
-	// Populate cache if missing
-	if s.tables == nil {
-		if _, err := s.Tables(); err != nil {
-			return nil, err
-		}
-	}
-
-	clone := &Schema{
-		Name:      s.Name,
-		CharSet:   s.CharSet,
-		Collation: s.Collation,
-		tables:    s.tables,
-	}
-	return clone, nil
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-// TestSchemaTables tests the input and output of Tables(), TablesByName(),
+// TestSchemaTables tests the input and output of Tables, TablesByName(),
 // HasTable(), and Table(). It does not explicitly validate the introspection
-// logic though; that's handled in TestSchemaIntrospection.
+// logic though; that's handled in TestInstanceSchemaIntrospection.
 func (s TengoIntegrationSuite) TestSchemaTables(t *testing.T) {
 	schema := s.GetSchema(t, "testing")
 
@@ -43,34 +43,6 @@ func (s TengoIntegrationSuite) TestSchemaTables(t *testing.T) {
 	}
 	if table := schema.Table("doesnt_exist"); table != nil {
 		t.Errorf("Expected Table(doesnt_exist) to return nil; instead found %v", table)
-	}
-}
-
-func (s TengoIntegrationSuite) TestSchemaIntrospection(t *testing.T) {
-	// Ensure our unit test fixtures and integration test fixtures match
-	schema, aTableFromDB := s.GetSchemaAndTable(t, "testing", "actor")
-	aTableFromUnit := aTable(1)
-	clauses, supported := aTableFromDB.Diff(&aTableFromUnit)
-	if !supported {
-		t.Error("Diff unexpectedly not supported for testing.actor")
-	} else if len(clauses) > 0 {
-		t.Errorf("Diff of testing.actor unexpectedly found %d clauses; expected 0", len(clauses))
-	}
-	aTableFromDB = s.GetTable(t, "testing", "actor_in_film")
-	aTableFromUnit = anotherTable()
-	clauses, supported = aTableFromDB.Diff(&aTableFromUnit)
-	if !supported {
-		t.Error("Diff unexpectedly not supported for testing.actor_in_film")
-	} else if len(clauses) > 0 {
-		t.Errorf("Diff of testing.actor_in_film unexpectedly found %d clauses; expected 0", len(clauses))
-	}
-
-	// ensure tables are all supported (except where known not to be)
-	for _, table := range schema.Tables {
-		shouldBeUnsupported := (table.Name == unsupportedTable().Name)
-		if table.UnsupportedDDL != shouldBeUnsupported {
-			t.Errorf("Table %s: expected UnsupportedDDL==%v, instead found %v", table.Name, shouldBeUnsupported, !shouldBeUnsupported)
-		}
 	}
 }
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -11,20 +11,17 @@ func (s TengoIntegrationSuite) TestSchemaTables(t *testing.T) {
 	schema := s.GetSchema(t, "testing")
 
 	// Currently at least 7 tables in testing schema in testdata/integration.sql
-	tables, err := schema.Tables()
-	if err != nil || len(tables) < 7 {
-		t.Errorf("Expected at least 7 tables, instead found %d, err=%s", len(tables), err)
+	if len(schema.Tables) < 7 {
+		t.Errorf("Expected at least 7 tables, instead found %d", len(schema.Tables))
 	}
 
 	// Ensure TablesByName is returning the same set of tables
-	byName, err := schema.TablesByName()
-	if err != nil {
-		t.Errorf("TablesByName returned error: %s", err)
-	} else if len(byName) != len(tables) {
-		t.Errorf("len(byName) != len(tables): %d vs %d", len(byName), len(tables))
+	byName := schema.TablesByName()
+	if len(byName) != len(schema.Tables) {
+		t.Errorf("len(byName) != len(tables): %d vs %d", len(byName), len(schema.Tables))
 	}
 	seen := make(map[string]bool, len(byName))
-	for _, table := range tables {
+	for _, table := range schema.Tables {
 		if seen[table.Name] {
 			t.Errorf("Table %s returned multiple times from call to instance.Tables", table.Name)
 		}
@@ -32,8 +29,8 @@ func (s TengoIntegrationSuite) TestSchemaTables(t *testing.T) {
 		if table != byName[table.Name] {
 			t.Errorf("Mismatch for table %s between Tables and TablesByName", table.Name)
 		}
-		if table2, err := schema.Table(table.Name); err != nil || table2 != table {
-			t.Errorf("Mismatch for table %s vs schema.Table(%s); error=%s", table.Name, table.Name, err)
+		if table2 := schema.Table(table.Name); table2 != table {
+			t.Errorf("Mismatch for table %s vs schema.Table(%s)", table.Name, table.Name)
 		}
 		if !schema.HasTable(table.Name) {
 			t.Errorf("Expected HasTable(%s)==true, instead found false", table.Name)
@@ -44,8 +41,8 @@ func (s TengoIntegrationSuite) TestSchemaTables(t *testing.T) {
 	if schema.HasTable("doesnt_exist") {
 		t.Error("HasTable(doesnt_exist) unexpectedly returning true")
 	}
-	if table, err := schema.Table("doesnt_exist"); table != nil || err != nil {
-		t.Errorf("Expected Table(doesnt_exist) to return nil,nil; instead found %v,%s", table, err)
+	if table := schema.Table("doesnt_exist"); table != nil {
+		t.Errorf("Expected Table(doesnt_exist) to return nil; instead found %v", table)
 	}
 }
 
@@ -69,11 +66,7 @@ func (s TengoIntegrationSuite) TestSchemaIntrospection(t *testing.T) {
 	}
 
 	// ensure tables are all supported (except where known not to be)
-	tables, err := schema.Tables()
-	if err != nil {
-		t.Fatalf("Unexpected error from schema.Tables(): %s", err)
-	}
-	for _, table := range tables {
+	for _, table := range schema.Tables {
 		shouldBeUnsupported := (table.Name == unsupportedTable().Name)
 		if table.UnsupportedDDL != shouldBeUnsupported {
 			t.Errorf("Table %s: expected UnsupportedDDL==%v, instead found %v", table.Name, shouldBeUnsupported, !shouldBeUnsupported)
@@ -107,7 +100,7 @@ func (s TengoIntegrationSuite) TestSchemaOverridesServerCharSet(t *testing.T) {
 		{testcharcollSchema, true, true},
 	}
 	for _, testRow := range testTable {
-		overrideCharset, overrideCollation, err := testRow.schema.OverridesServerCharSet()
+		overrideCharset, overrideCollation, err := testRow.schema.OverridesServerCharSet(s.d.Instance)
 		if err != nil {
 			t.Errorf("Unexpected error from OverridesServerCharSet: %s", err)
 		} else {
@@ -122,49 +115,7 @@ func (s TengoIntegrationSuite) TestSchemaOverridesServerCharSet(t *testing.T) {
 
 	// Confirm error returned from calling method on a nil schema
 	var nilSchema *Schema
-	if _, _, err = nilSchema.OverridesServerCharSet(); err == nil {
+	if _, _, err = nilSchema.OverridesServerCharSet(s.d.Instance); err == nil {
 		t.Error("Expected OverridesServerCharSet to return error for nil schema, but it did not")
-	}
-}
-
-func (s TengoIntegrationSuite) TestSchemaCachedCopy(t *testing.T) {
-	schema := s.GetSchema(t, "testing")
-
-	clone, err := schema.CachedCopy()
-	if err != nil {
-		t.Errorf("Unexpected error from schema.CachedCopy(): %s", err)
-	}
-
-	// Confirm diff still works
-	sd, err := clone.Diff(schema)
-	if err != nil {
-		t.Errorf("Unexpected error from diff on a cached-copy schema: %s", err)
-	} else if len(sd.TableDiffs) > 0 {
-		t.Error("Non-empty diff unexpectedly returned")
-	}
-
-	// Confirm PurgeTableCache intentionally does not purge anything on a detached
-	// instance
-	if clone.tables == nil {
-		t.Fatal("Incorrect assumption of test (cached copy of schema should already have table cache pre-populated)")
-	}
-	clone.PurgeTableCache()
-	if clone.tables == nil {
-		t.Error("Expected PurgeTableCache to be a no-op on a detached schema, but it was not")
-	}
-
-	// Confirm that methods requiring an instance return an error
-	if _, _, err = clone.OverridesServerCharSet(); err == nil {
-		t.Error("Expected OverridesServerCharSet to fail with detached instance, but it did not")
-	}
-	clone.tables = nil
-	if _, err = clone.Tables(); err == nil {
-		t.Error("Expected Tables() to fail with detached instance with artificially purged table cache, but it did not")
-	}
-
-	// Confirm CachedCopy of nil schema is nil
-	var nilSchema *Schema
-	if clone, err = nilSchema.CachedCopy(); clone != nil || err != nil {
-		t.Error("Cached copy of nil schema did work as expected")
 	}
 }

--- a/table_test.go
+++ b/table_test.go
@@ -8,43 +8,20 @@ import (
 func TestTableGeneratedCreateStatement(t *testing.T) {
 	for nextAutoInc := uint64(1); nextAutoInc < 3; nextAutoInc++ {
 		table := aTable(nextAutoInc)
-		if table.GeneratedCreateStatement() != table.createStatement {
-			t.Errorf("Generated DDL does not match actual DDL\nExpected:\n%s\nFound:\n%s", table.createStatement, table.GeneratedCreateStatement())
+		if table.GeneratedCreateStatement() != table.CreateStatement {
+			t.Errorf("Generated DDL does not match actual DDL\nExpected:\n%s\nFound:\n%s", table.CreateStatement, table.GeneratedCreateStatement())
 		}
 	}
 
 	table := anotherTable()
-	if table.GeneratedCreateStatement() != table.createStatement {
-		t.Errorf("Generated DDL does not match actual DDL\nExpected:\n%s\nFound:\n%s", table.createStatement, table.GeneratedCreateStatement())
+	if table.GeneratedCreateStatement() != table.CreateStatement {
+		t.Errorf("Generated DDL does not match actual DDL\nExpected:\n%s\nFound:\n%s", table.CreateStatement, table.GeneratedCreateStatement())
 	}
 
 	table = unsupportedTable()
-	if table.GeneratedCreateStatement() == table.createStatement {
+	if table.GeneratedCreateStatement() == table.CreateStatement {
 		t.Error("Expected unsupported table's generated DDL to differ from actual DDL, but they match")
 	}
-}
-
-func TestTableCreateStatement(t *testing.T) {
-	table := aTable(1)
-	if table.CreateStatement() != table.createStatement {
-		t.Error("table.CreateStatement returned unexpected result")
-	}
-
-	// Confirm missing value causes method to panic
-	table.createStatement = ""
-	func() {
-		var didPanic bool
-		defer func() {
-			r := recover()
-			if r != nil {
-				didPanic = true
-			}
-		}()
-		table.CreateStatement()
-		if !didPanic {
-			t.Error("Expected panic on Table.CreateStatement() without prepopulated data, but did not panic.")
-		}
-	}()
 }
 
 func TestTableAlterAddOrDropColumn(t *testing.T) {
@@ -61,7 +38,7 @@ func TestTableAlterAddOrDropColumn(t *testing.T) {
 	to.Columns = append(to.Columns, newCol)
 	colCount := len(to.Columns)
 	to.Columns[colCount-2], to.Columns[colCount-1] = to.Columns[colCount-1], to.Columns[colCount-2]
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported := from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -100,7 +77,7 @@ func TestTableAlterAddOrDropColumn(t *testing.T) {
 	}
 	to.Columns = []*Column{anotherCol}
 	to.Columns = append(to.Columns, hadColumns...)
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 2 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 2, found %d", len(tableAlters))
@@ -124,7 +101,7 @@ func TestTableAlterAddOrDropColumn(t *testing.T) {
 		Default:  ColumnDefaultValue("0"),
 	}
 	to.Columns = append(to.Columns, anotherCol)
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 3 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 3, found %d", len(tableAlters))
@@ -152,7 +129,7 @@ func TestTableAlterAddOrDropIndex(t *testing.T) {
 		SubParts: []uint16{0, 10},
 	}
 	to.SecondaryIndexes = append(to.SecondaryIndexes, newSecondary)
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported := from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -181,7 +158,7 @@ func TestTableAlterAddOrDropIndex(t *testing.T) {
 	// Start over; change an existing secondary index
 	to = aTable(1)
 	to.SecondaryIndexes[0].Unique = false
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 2 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 2, found %d", len(tableAlters))
@@ -205,7 +182,7 @@ func TestTableAlterAddOrDropIndex(t *testing.T) {
 	to = aTable(1)
 	to.PrimaryKey.Columns = append(to.PrimaryKey.Columns, to.Columns[4])
 	to.PrimaryKey.SubParts = append(to.PrimaryKey.SubParts, 0)
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 2 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 2, found %d", len(tableAlters))
@@ -227,7 +204,7 @@ func TestTableAlterAddOrDropIndex(t *testing.T) {
 
 	// Remove the primary key
 	to.PrimaryKey = nil
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -263,7 +240,7 @@ func TestTableAlterModifyColumn(t *testing.T) {
 	movedCol := to.Columns[movedColPos]
 	to.Columns = append(to.Columns[:movedColPos], to.Columns[movedColPos+1:]...)
 	to.Columns = append([]*Column{movedCol}, to.Columns...)
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported := from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -285,7 +262,7 @@ func TestTableAlterModifyColumn(t *testing.T) {
 	shouldBeAfter := to.Columns[len(to.Columns)-1]
 	to.Columns = append(to.Columns[:movedColPos], to.Columns[movedColPos+1:]...)
 	to.Columns = append(to.Columns, movedCol)
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -303,7 +280,7 @@ func TestTableAlterModifyColumn(t *testing.T) {
 
 	// Repos to last position AND change column definition
 	movedCol.Nullable = !movedCol.Nullable
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -331,7 +308,7 @@ func TestTableAlterModifyColumn(t *testing.T) {
 		Default:  ColumnDefaultNull,
 	}
 	to.Columns = append(to.Columns[0:3], to.Columns[5], to.Columns[6], newCol, to.Columns[4])
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 3 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 3, found %d", len(tableAlters))
@@ -365,7 +342,7 @@ func TestTableAlterModifyColumn(t *testing.T) {
 	// Start over; just change a column definition without moving anything
 	to = aTable(1)
 	to.Columns[4].TypeInDB = "varchar(10)"
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Fatalf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -388,7 +365,7 @@ func TestTableAlterChangeStorageEngine(t *testing.T) {
 	getTableWithEngine := func(engine string) Table {
 		t := aTable(1)
 		t.Engine = engine
-		t.createStatement = t.GeneratedCreateStatement()
+		t.CreateStatement = t.GeneratedCreateStatement()
 		return t
 	}
 	assertChangeEngine := func(a, b *Table, expected string) {
@@ -452,7 +429,7 @@ func TestTableAlterChangeAutoIncrement(t *testing.T) {
 	// Removing an auto-inc col and changing auto inc next value: should NOT emit
 	// an auto-inc change since "to" table no longer has one
 	to.Columns = to.Columns[1:]
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	tableAlters, supported = from.Diff(&to)
 	if len(tableAlters) != 1 || !supported {
 		t.Errorf("Incorrect number of table alters: expected 1, found %d", len(tableAlters))
@@ -467,8 +444,8 @@ func TestTableAlterChangeAutoIncrement(t *testing.T) {
 	// starting value: one clause for new col, another for auto-inc val (in that order!)
 	to.NextAutoIncrement = 0
 	from.NextAutoIncrement = 3
-	to.createStatement = to.GeneratedCreateStatement()
-	from.createStatement = from.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
+	from.CreateStatement = from.GeneratedCreateStatement()
 	tableAlters, supported = to.Diff(&from)
 	if len(tableAlters) != 2 || !supported {
 		t.Errorf("Incorrect number of table alters: expected 2, found %d", len(tableAlters))
@@ -487,7 +464,7 @@ func TestTableAlterChangeCharSet(t *testing.T) {
 		t := aTable(1)
 		t.CharSet = charSet
 		t.Collation = collation
-		t.createStatement = t.GeneratedCreateStatement()
+		t.CreateStatement = t.GeneratedCreateStatement()
 		return t
 	}
 	assertChangeCharSet := func(a, b *Table, expected string) {
@@ -531,7 +508,7 @@ func TestTableAlterChangeCreateOptions(t *testing.T) {
 	getTableWithCreateOptions := func(createOptions string) Table {
 		t := aTable(1)
 		t.CreateOptions = createOptions
-		t.createStatement = t.GeneratedCreateStatement()
+		t.CreateStatement = t.GeneratedCreateStatement()
 		return t
 	}
 	assertChangeCreateOptions := func(a, b *Table, expected string) {
@@ -594,7 +571,7 @@ func TestTableAlterChangeComment(t *testing.T) {
 	getTableWithComment := func(comment string) Table {
 		t := aTable(1)
 		t.Comment = comment
-		t.createStatement = t.GeneratedCreateStatement()
+		t.CreateStatement = t.GeneratedCreateStatement()
 		return t
 	}
 	assertChangeComment := func(a, b *Table, expected string) {
@@ -634,7 +611,7 @@ func TestTableAlterUnsupportedTable(t *testing.T) {
 		Default:  ColumnDefaultNull,
 	}
 	to.Columns = append(to.Columns, newCol)
-	to.createStatement = to.GeneratedCreateStatement()
+	to.CreateStatement = to.GeneratedCreateStatement()
 	if tableAlters, supported := from.Diff(&to); len(tableAlters) != 0 || supported {
 		t.Fatalf("Expected diff of unsupported tables to yield no alters; instead found %d", len(tableAlters))
 	}

--- a/tengo_test.go
+++ b/tengo_test.go
@@ -51,18 +51,18 @@ func (s *TengoIntegrationSuite) GetSchema(t *testing.T, schemaName string) *Sche
 	return schema
 }
 
-func (s *TengoIntegrationSuite) GetTable(t *testing.T, schemaName string, tableName string) *Table {
+func (s *TengoIntegrationSuite) GetTable(t *testing.T, schemaName, tableName string) *Table {
 	t.Helper()
 	_, table := s.GetSchemaAndTable(t, schemaName, tableName)
 	return table
 }
 
-func (s *TengoIntegrationSuite) GetSchemaAndTable(t *testing.T, schemaName string, tableName string) (*Schema, *Table) {
+func (s *TengoIntegrationSuite) GetSchemaAndTable(t *testing.T, schemaName, tableName string) (*Schema, *Table) {
 	t.Helper()
 	schema := s.GetSchema(t, schemaName)
-	table, err := schema.Table(tableName)
-	if table == nil || err != nil {
-		t.Fatalf("Unable to obtain table %s.%s: %s", schemaName, tableName, err)
+	table := schema.Table(tableName)
+	if table == nil {
+		t.Fatalf("Table %s.%s unexpectedly does not exist", schemaName, tableName)
 	}
 	return schema, table
 }
@@ -217,7 +217,7 @@ func aSchema(name string, tables ...*Table) Schema {
 		Name:      name,
 		CharSet:   "latin1",
 		Collation: "latin1_swedish_ci",
-		tables:    tables,
+		Tables:    tables,
 	}
 	return s
 }

--- a/tengo_test.go
+++ b/tengo_test.go
@@ -156,7 +156,7 @@ func aTable(nextAutoInc uint64) Table {
 		PrimaryKey:        primaryKey(columns[0]),
 		SecondaryIndexes:  secondaryIndexes,
 		NextAutoIncrement: nextAutoInc,
-		createStatement:   stmt,
+		CreateStatement:   stmt,
 	}
 }
 
@@ -191,14 +191,14 @@ func anotherTable() Table {
 		Columns:          columns,
 		PrimaryKey:       primaryKey(columns[0], columns[1]),
 		SecondaryIndexes: []*Index{secondaryIndex},
-		createStatement:  stmt,
+		CreateStatement:  stmt,
 	}
 }
 
 func unsupportedTable() Table {
 	t := anotherTable()
 	t.Name += "_with_fk"
-	t.createStatement = `CREATE TABLE ` + "`" + `actor_in_film_with_fk` + "`" + ` (
+	t.CreateStatement = `CREATE TABLE ` + "`" + `actor_in_film_with_fk` + "`" + ` (
   ` + "`" + `actor_id` + "`" + ` smallint(5) unsigned NOT NULL,
   ` + "`" + `film_name` + "`" + ` varchar(60) NOT NULL,
   PRIMARY KEY (` + "`" + `actor_id` + "`" + `,` + "`" + `film_name` + "`" + `),

--- a/testdata/integration.sql
+++ b/testdata/integration.sql
@@ -72,7 +72,7 @@ CREATE TABLE grab_bag (
 	name varchar(100) NOT NULL,
 	code char(8) DEFAULT 'XYZ01234',
 	created_at timestamp(2) DEFAULT CURRENT_TIMESTAMP(2),
-	updated_at timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	updated_at timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	alive tinyint(1) DEFAULT '1' COMMENT 'column comment',
 	flags bit(8) DEFAULT b'1',
 	PRIMARY KEY (id, code),
@@ -80,6 +80,16 @@ CREATE TABLE grab_bag (
 	INDEX recency (updated_at, created_at),
 	INDEX owner_idx (owner_id) COMMENT 'index comment'
 ) AUTO_INCREMENT=123;
+
+CREATE TABLE partitioned (
+	id int unsigned NOT NULL AUTO_INCREMENT,
+	customer_id int unsigned NOT NULL,
+	info text,
+	PRIMARY KEY (id, customer_id)
+) ENGINE=InnoDB ROW_FORMAT=REDUNDANT PARTITION BY RANGE (customer_id) (
+	PARTITION p0 VALUES LESS THAN (123),
+	PARTITION p1 VALUES LESS THAN MAXVALUE
+);
 
 use testcharcoll
 

--- a/testing.go
+++ b/testing.go
@@ -234,12 +234,12 @@ func (di *DockerizedInstance) Destroy() error {
 // mysql-server, making it useful as a per-test cleanup method in
 // implementations of IntegrationTestSuite.BeforeTest.
 func (di *DockerizedInstance) NukeData() error {
-	schemas, err := di.Instance.Schemas()
+	schemas, err := di.Instance.SchemaNames()
 	if err != nil {
 		return err
 	}
-	for _, s := range schemas {
-		if err := di.DropSchema(s, false); err != nil {
+	for _, schema := range schemas {
+		if err := di.DropSchema(schema, false); err != nil {
 			return err
 		}
 	}
@@ -275,7 +275,6 @@ func (di *DockerizedInstance) SourceSQL(filePath string) (string, error) {
 	if err = di.DockerClient.StartExec(exec.ID, startOpts); err != nil {
 		return "", err
 	}
-	di.purgeSchemaCache()
 	stdoutStr := stdout.String()
 	stderrStr := strings.Replace(stderr.String(), "Warning: Using a password on the command line interface can be insecure.\n", "", 1)
 	if strings.Contains(stderrStr, "ERROR") {


### PR DESCRIPTION
This PR removes the internal caching of instances and schemas, and simplifies the args and/or return values of several methods by removing lazy-loading. The built-in caching and lazy-loading added too much complexity for too little benefit. Callers should implement more appropriate special-purpose caching if ever needed.

This is a breaking API change, which is acceptable since Go La Tengo is still pre-1.0. The following method signatures or return semantics changed:

* NewInstance() no longer de-duplicates instances, and no longer errors upon creating a duplicate instance with different auth or params.
* Instance.HasSchema() now returns an error if its query fails
* The following methods now take string args instead of structs:
  * Instance.ShowCreateTable()
  * Instance.TableSize()
  * Instance.TableHasRows()
  * Instance.DropSchema()
  * Instance.AlterSchema()
  * Instance.DropTablesInSchema()
  * Instance.CloneSchema()
* The following methods no longer possibly return an error:
  * NewSchemaDiff()
  * Schema.TablesByName()
  * Schema.Table()
* Schema.OverridesServerCharSet() now takes an Instance as an arg
* The following methods have been replaced with identically-named exported fields:
  * Schema.Tables()
  * Table.CreateStatement()
* The following methods have been removed entirely, as they are no longer needed now that there's no internal caching:
  * Schema.PurgeTableCache()
  * Schema.CachedCopy()
