### PR TITLE
Table.Diff(): Support re-ordering indexes

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,8 +30,8 @@
   name = "github.com/VividCortex/mysqlerr"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/fsouza/go-dockerclient"
+  version = "1.2.1"
 
 [[constraint]]
   name = "github.com/go-sql-driver/mysql"

--- a/alterclause.go
+++ b/alterclause.go
@@ -9,7 +9,7 @@ import (
 
 // TableAlterClause interface represents a specific single-element difference
 // between two tables. Structs satisfying this interface can generate an ALTER
-// TABLE clause, such as ADD COLUMN, MODIFY COLUMN, ADD INDEX, etc.
+// TABLE clause, such as ADD COLUMN, MODIFY COLUMN, ADD KEY, etc.
 type TableAlterClause interface {
 	Clause() string
 	Unsafe() bool
@@ -71,15 +71,15 @@ func (dc DropColumn) Unsafe() bool {
 
 ///// AddIndex /////////////////////////////////////////////////////////////////
 
-// AddIndex represents a new index that is present on the right-side ("to")
-// schema version of the table, but not the left-side ("from") version. It
-// satisfies the TableAlterClause interface.
+// AddIndex represents an index that is present on the right-side ("to")
+// schema version of the table, but was not identically present on the left-
+// side ("from") version. It satisfies the TableAlterClause interface.
 type AddIndex struct {
 	Table *Table
 	Index *Index
 }
 
-// Clause returns an ADD INDEX clause of an ALTER TABLE statement.
+// Clause returns an ADD KEY clause of an ALTER TABLE statement.
 func (ai AddIndex) Clause() string {
 	return fmt.Sprintf("ADD %s", ai.Index.Definition())
 }
@@ -93,19 +93,19 @@ func (ai AddIndex) Unsafe() bool {
 ///// DropIndex ////////////////////////////////////////////////////////////////
 
 // DropIndex represents an index that was present on the left-side ("from")
-// schema version of the table, but not the right-side ("to") version. It
-// satisfies the TableAlterClause interface.
+// schema version of the table, but not identically present the right-side
+// ("to") version. It satisfies the TableAlterClause interface.
 type DropIndex struct {
 	Table *Table
 	Index *Index
 }
 
-// Clause returns a DROP INDEX clause of an ALTER TABLE statement.
+// Clause returns a DROP KEY clause of an ALTER TABLE statement.
 func (di DropIndex) Clause() string {
 	if di.Index.PrimaryKey {
 		return "DROP PRIMARY KEY"
 	}
-	return fmt.Sprintf("DROP INDEX %s", EscapeIdentifier(di.Index.Name))
+	return fmt.Sprintf("DROP KEY %s", EscapeIdentifier(di.Index.Name))
 }
 
 // Unsafe returns true if this clause is potentially destructive of data.

--- a/diff.go
+++ b/diff.go
@@ -28,11 +28,12 @@ const (
 // for a particular table, and/or generate errors if certain clauses are
 // present.
 type StatementModifiers struct {
-	NextAutoInc     NextAutoIncMode // How to handle differences in next-auto-inc values
-	AllowUnsafe     bool            // Whether to allow potentially-destructive DDL (drop table, drop column, modify col type, etc)
-	LockClause      string          // Include a LOCK=[value] clause in generated ALTER TABLE
-	AlgorithmClause string          // Include an ALGORITHM=[value] clause in generated ALTER TABLE
-	IgnoreTable     *regexp.Regexp  // Generate blank DDL if table name matches this regexp
+	NextAutoInc      NextAutoIncMode // How to handle differences in next-auto-inc values
+	AllowUnsafe      bool            // Whether to allow potentially-destructive DDL (drop table, drop column, modify col type, etc)
+	LockClause       string          // Include a LOCK=[value] clause in generated ALTER TABLE
+	AlgorithmClause  string          // Include an ALGORITHM=[value] clause in generated ALTER TABLE
+	IgnoreTable      *regexp.Regexp  // Generate blank DDL if table name matches this regexp
+	StrictIndexOrder bool            // If true, maintain index order even in cases where there is no functional difference
 }
 
 // SchemaDiff stores a set of differences between two database schemas.
@@ -338,15 +339,44 @@ func (td *TableDiff) alterStatement(mods StatementModifiers) (string, error) {
 		}
 	}
 
+	// Ignore index repositioning, unless StrictIndexOrder enabled, or unless the
+	// order is actually relevant to the clustered index key
+	trivialIndexMoves := make(map[string]bool)
+	if mods.StrictIndexOrder || td.To.ClusteredIndexKey() != td.To.PrimaryKey {
+		// Iterate through the clauses to find cases where we drop an index and then
+		// later re-add the exact same index. (Note that the drop will *always* come
+		// before the subsequent re-add in td.alterClauses in this case.)
+		droppedIndexes := make(map[string]*Index)
+		for _, clause := range td.alterClauses {
+			switch clause := clause.(type) {
+			case DropIndex:
+				droppedIndexes[clause.Index.Name] = clause.Index
+			case AddIndex:
+				if index, dropped := droppedIndexes[clause.Index.Name]; dropped && index.Equals(clause.Index) {
+					trivialIndexMoves[clause.Index.Name] = true
+				}
+			}
+		}
+	}
+
 	clauseStrings := make([]string, 0, len(td.alterClauses))
 	var err error
 	for _, clause := range td.alterClauses {
-		if clause, ok := clause.(ChangeAutoIncrement); ok {
+		switch clause := clause.(type) {
+		case ChangeAutoIncrement:
 			if mods.NextAutoInc == NextAutoIncIgnore {
 				continue
 			} else if mods.NextAutoInc == NextAutoIncIfIncreased && clause.OldNextAutoIncrement >= clause.NewNextAutoIncrement {
 				continue
 			} else if mods.NextAutoInc == NextAutoIncIfAlready && clause.OldNextAutoIncrement <= 1 {
+				continue
+			}
+		case DropIndex:
+			if trivialIndexMoves[clause.Index.Name] {
+				continue
+			}
+		case AddIndex:
+			if trivialIndexMoves[clause.Index.Name] {
 				continue
 			}
 		}

--- a/diff.go
+++ b/diff.go
@@ -342,7 +342,7 @@ func (td *TableDiff) alterStatement(mods StatementModifiers) (string, error) {
 	// Ignore index repositioning, unless StrictIndexOrder enabled, or unless the
 	// order is actually relevant to the clustered index key
 	trivialIndexMoves := make(map[string]bool)
-	if mods.StrictIndexOrder || td.To.ClusteredIndexKey() != td.To.PrimaryKey {
+	if !mods.StrictIndexOrder && td.To.ClusteredIndexKey() == td.To.PrimaryKey {
 		// Iterate through the clauses to find cases where we drop an index and then
 		// later re-add the exact same index. (Note that the drop will *always* come
 		// before the subsequent re-add in td.alterClauses in this case.)

--- a/table.go
+++ b/table.go
@@ -184,22 +184,31 @@ func (t *Table) Diff(to *Table) (clauses []TableAlterClause, supported bool) {
 		}
 	}
 
-	// Compare secondary indexes
-	fromIndexes := from.SecondaryIndexesByName()
+	// Compare secondary indexes. There is no way to modify an index without
+	// dropping and re-adding it. There's also no way to re-position an index
+	// without dropping and re-adding all preexisting indexes that now come after.
 	toIndexes := to.SecondaryIndexesByName()
-	for _, fromIdx := range fromIndexes {
-		toIdx, stillExists := toIndexes[fromIdx.Name]
-		if !stillExists {
+	fromIndexStillExist := make([]*Index, 0) // ordered list of indexes from "from" that still exist in "to"
+	for _, fromIdx := range from.SecondaryIndexes {
+		if _, stillExists := toIndexes[fromIdx.Name]; stillExists {
+			fromIndexStillExist = append(fromIndexStillExist, fromIdx)
+		} else {
 			clauses = append(clauses, DropIndex{Table: to, Index: fromIdx})
-		} else if !fromIdx.Equals(toIdx) {
-			drop := DropIndex{Table: to, Index: fromIdx}
-			add := AddIndex{Table: to, Index: toIdx}
-			clauses = append(clauses, drop, add)
 		}
 	}
+	var fromCursor int
 	for _, toIdx := range to.SecondaryIndexes {
-		if _, existedBefore := fromIndexes[toIdx.Name]; !existedBefore {
+		for fromCursor < len(fromIndexStillExist) && !fromIndexStillExist[fromCursor].Equals(toIdx) {
+			clauses = append(clauses, DropIndex{Table: to, Index: fromIndexStillExist[fromCursor]})
+			fromCursor++
+		}
+		if fromCursor >= len(fromIndexStillExist) {
+			// Already went through everything in the "from" list, so all remaining "to"
+			// indexes are adds
 			clauses = append(clauses, AddIndex{Table: to, Index: toIdx})
+		} else {
+			// Current position "to" matches cursor position "from"; nothing to add or drop
+			fromCursor++
 		}
 	}
 

--- a/table_test.go
+++ b/table_test.go
@@ -373,14 +373,14 @@ func TestTableAlterIndexReorder(t *testing.T) {
 			t.Errorf("Expected tableAlters[1] to add %s, instead added %s", orig[1].Name, add.Index.Name)
 		}
 		assertClauses(&from, &to, false, "")
-		assertClauses(&from, &to, true, "DROP INDEX `%s`, ADD %s", orig[1].Name, orig[1].Definition())
+		assertClauses(&from, &to, true, "DROP KEY `%s`, ADD %s", orig[1].Name, orig[1].Definition())
 	}
 
 	// Clustered index key changes: same effect as mods.StrictIndexOrder
 	to.PrimaryKey = nil
 	to.CreateStatement = to.GeneratedCreateStatement()
-	assertClauses(&from, &to, false, "DROP PRIMARY KEY, DROP INDEX `%s`, ADD %s", orig[1].Name, orig[1].Definition())
-	assertClauses(&from, &to, true, "DROP PRIMARY KEY, DROP INDEX `%s`, ADD %s", orig[1].Name, orig[1].Definition())
+	assertClauses(&from, &to, false, "DROP PRIMARY KEY, DROP KEY `%s`, ADD %s", orig[1].Name, orig[1].Definition())
+	assertClauses(&from, &to, true, "DROP PRIMARY KEY, DROP KEY `%s`, ADD %s", orig[1].Name, orig[1].Definition())
 
 	// Restore to previous state, and then modify [1]. Resulting diff should drop
 	// [1] and [2], then re-add the modified [1], and then re-add the unmodified
@@ -410,8 +410,8 @@ func TestTableAlterIndexReorder(t *testing.T) {
 				t.Errorf("tableAlters[3] does not match expectations; found %+v", add4.Index)
 			}
 		}
-		assertClauses(&from, &to, false, "DROP INDEX `%s`, ADD %s", orig[1].Name, to.SecondaryIndexes[1].Definition())
-		assertClauses(&from, &to, true, "DROP INDEX `%s`, DROP INDEX `%s`, ADD %s, ADD %s", orig[1].Name, orig[2].Name, to.SecondaryIndexes[1].Definition(), orig[2].Definition())
+		assertClauses(&from, &to, false, "DROP KEY `%s`, ADD %s", orig[1].Name, to.SecondaryIndexes[1].Definition())
+		assertClauses(&from, &to, true, "DROP KEY `%s`, DROP KEY `%s`, ADD %s, ADD %s", orig[1].Name, orig[2].Name, to.SecondaryIndexes[1].Definition(), orig[2].Definition())
 	}
 
 	// Adding a new index before [1] should also result in dropping the old [1]
@@ -430,7 +430,7 @@ func TestTableAlterIndexReorder(t *testing.T) {
 		t.Errorf("Expected 5 clauses, instead found %d", len(tableAlters))
 	} else {
 		assertClauses(&from, &to, false, "ADD %s", newIdx.Definition())
-		assertClauses(&from, &to, true, "DROP INDEX `%s`, DROP INDEX `%s`, ADD %s, ADD %s, ADD %s", orig[1].Name, orig[2].Name, newIdx.Definition(), orig[1].Definition(), orig[2].Definition())
+		assertClauses(&from, &to, true, "DROP KEY `%s`, DROP KEY `%s`, ADD %s, ADD %s, ADD %s", orig[1].Name, orig[2].Name, newIdx.Definition(), orig[1].Definition(), orig[2].Definition())
 	}
 
 	// The opposite operation -- dropping the new index that we put before [1] --
@@ -444,8 +444,8 @@ func TestTableAlterIndexReorder(t *testing.T) {
 		} else if drop.Index.Name != newIdx.Name {
 			t.Errorf("Expected tableAlters[0] to drop %s, instead dropped %s", newIdx.Name, drop.Index.Name)
 		}
-		assertClauses(&to, &from, false, "DROP INDEX `%s`", newIdx.Name)
-		assertClauses(&to, &from, true, "DROP INDEX `%s`", newIdx.Name)
+		assertClauses(&to, &from, false, "DROP KEY `%s`", newIdx.Name)
+		assertClauses(&to, &from, true, "DROP KEY `%s`", newIdx.Name)
 	}
 }
 

--- a/testdata/integration.sql
+++ b/testdata/integration.sql
@@ -76,9 +76,9 @@ CREATE TABLE grab_bag (
 	alive tinyint(1) DEFAULT '1' COMMENT 'column comment',
 	flags bit(8) DEFAULT b'1',
 	PRIMARY KEY (id, code),
-	UNIQUE INDEX name_idx (name),
-	INDEX recency (updated_at, created_at),
-	INDEX owner_idx (owner_id) COMMENT 'index comment'
+	UNIQUE KEY name_idx (name),
+	KEY recency (updated_at, created_at),
+	KEY owner_idx (owner_id) COMMENT 'index comment'
 ) AUTO_INCREMENT=123;
 
 CREATE TABLE partitioned (


### PR DESCRIPTION
Previously, when diff'ing tables, Go La Tengo did not consider secondary index order to be significant; usually it has no functional impact in MySQL/InnoDB. However, this caused two rare problems:

* Although applying the generated set of ALTERs to the "from" side of a diff would indeed yield a table that is *functionally* equivalent to the "to" side of the diff, the canonical table definition (e.g. output of `SHOW CREATE TABLE`) would still differ, due to the order of index clauses being different.
* Index order has a functional impact in one rare edge case: InnoDB tables with no primary key, but multiple unique keys with all non-nullable columns. In this case, InnoDB will use the first such unique index for the clustered index.

This PR makes Table.Diff() able to maintain index ordering. By default, however, the generated TableDiff.Statement() will automatically strip out index operations that simply reorder indexes -- preserving the previous behavior, as this generates a faster-to-execute set of ALTERs by avoiding needlessly recreated indexes whose definitions have not changed. The index reordering operations are only used in two cases: whenever index order is actually relevant (2nd bullet above), or whenever the new option StatementModifiers.StrictIndexOrder is true.