### PR TITLE
Add SourceString and Source methods to DockerizedInstance

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -295,6 +296,30 @@ func (di *DockerizedInstance) SourceSQL(filePath string) (string, error) {
 		return "", fmt.Errorf("SourceSQL %s: Unable to open setup file %s: %s", di, filePath, err)
 	}
 	defer f.Close()
+	stdoutStr, err := di.Source(f)
+	if err != nil {
+		return stdoutStr, fmt.Errorf("SourceSQL %s: Error sourcing file %s: %v", di, filePath, err)
+	}
+	return stdoutStr, nil
+}
+
+// SourceString reads the specified string and executes it against the containerized
+// mysql-server. The string should contain one or more valid SQL instructions,
+// typically a mix of DML and/or DDL statements. It is useful as a per-test
+// setup method in implementations of IntegrationTestSuite.BeforeTest.
+func (di *DockerizedInstance) SourceString(str string) (string, error) {
+	stdoutStr, err := di.Source(strings.NewReader(str))
+	if err != nil {
+		return stdoutStr, fmt.Errorf("SourceString %s: Error sourcing string %s: %v", di, str, err)
+	}
+	return stdoutStr, nil
+}
+
+// Source reads from the io.Reader and executes it against the containerized
+// mysql-server. The io.Reader should contain one or more valid SQL instructions,
+// typically a mix of DML and/or DDL statements. It is useful as a per-test
+// setup method in implementations of IntegrationTestSuite.BeforeTest.
+func (di *DockerizedInstance) Source(reader io.Reader) (string, error) {
 	cmd := []string{"mysql", "-tvvv", "-u", "root"}
 	if di.RootPassword != "" {
 		cmd = append(cmd, fmt.Sprintf("-p%s", di.RootPassword))
@@ -314,7 +339,7 @@ func (di *DockerizedInstance) SourceSQL(filePath string) (string, error) {
 	seopts := docker.StartExecOptions{
 		OutputStream: &stdout,
 		ErrorStream:  &stderr,
-		InputStream:  f,
+		InputStream:  reader,
 	}
 	if err = di.Manager.client.StartExec(exec.ID, seopts); err != nil {
 		return "", err
@@ -322,7 +347,7 @@ func (di *DockerizedInstance) SourceSQL(filePath string) (string, error) {
 	stdoutStr := stdout.String()
 	stderrStr := strings.Replace(stderr.String(), "Warning: Using a password on the command line interface can be insecure.\n", "", 1)
 	if strings.Contains(stderrStr, "ERROR") {
-		return stdoutStr, fmt.Errorf("SourceSQL %s: Error sourcing file %s: %s", di, filePath, stderrStr)
+		return stdoutStr, errors.New(stderrStr)
 	}
 	return stdoutStr, nil
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -91,6 +91,13 @@ func TestDocker(t *testing.T) {
 		t.Error("Expected error attempting to SourceSQL non-SQL file, instead got nil")
 	}
 
+	if _, err := di.SourceString("CREATE DATABASE testing2"); err != nil {
+		t.Errorf("Unexpected error SourceString: %s", err)
+	}
+	if _, err := di.SourceString("BAD SQL stmt"); err == nil {
+		t.Error("Expected error attempting to SourceString invalid string, instead got nil")
+	}
+
 	if err := di.Destroy(); err != nil {
 		t.Fatalf("Unexpected error from Destroy: %s", err)
 	}


### PR DESCRIPTION
Added the ability to source a string rather than a file. Also exposed the new method `Source` which takes an `io.Reader` allowing for any implementation.

Ideally, `SourceSQL` would be renamed to `SourceFile`, but I didn't want to break backwards compatibility.

Let me know what you think!